### PR TITLE
[WIP]: add utils for checking `test` arg types

### DIFF
--- a/rules/utils.js
+++ b/rules/utils.js
@@ -1,0 +1,126 @@
+module.exports.isValidTestName = isValidTestName;
+module.exports.isValidTestFunction = isValidTestFunction;
+
+function always() {
+	return 'definitely';
+}
+
+function maybe() {
+	return 'maybe';
+}
+
+function or(a, b) {
+	if (a === 'definitely' || b === 'definitely') {
+		return 'definitely';
+	}
+
+	if (a || b) {
+		return 'maybe';
+	}
+
+	return false;
+}
+
+function and(a, b) {
+	if (a === 'definitely' && b === 'definitely') {
+		return 'definitely';
+	}
+
+	if (a && b) {
+		return 'maybe';
+	}
+
+	return false;
+}
+
+// TODO: delete things once we are confident they could never be a valid test name.
+var TEST_NAME_TYPES = {
+	ArrayExpression: false,
+	ArrowFunctionExpression: false,
+	AssignmentExpression: function (node) {
+		return (node.operator === '+=' || node.operator === '=') && isValidTestName(node.right);
+	},
+	AwaitExpression: false, // CAUTION: It's deferred to ES7.
+	BinaryExpression: function (node) {
+		return node.operator === '+' && or(isValidTestName(node.left), isValidTestName(node.right));
+	},
+	CallExpression: maybe,
+	ClassExpression: false,
+	ComprehensionExpression: false,  // CAUTION: It's deferred to ES7.
+	ConditionalExpression: function (node) {
+		return and(isValidTestName(node.consequent), isValidTestName(node.alternate));
+	},
+	FunctionDeclaration: false,
+	FunctionExpression: false,
+	GeneratorExpression: false,  // CAUTION: It's deferred to ES7.
+	Identifier: maybe,
+	Literal: function (node) {
+		return (typeof node.value === 'string') && 'definitely';
+	},
+	LogicalExpression: function (node) {
+		return node.operator === '||' && and(isValidTestName(node.left), isValidTestName(node.right)); // TODO: only || if operator === '||' - otherwise right must be
+	},
+	MemberExpression: maybe,
+	NewExpression: false,
+	ObjectExpression: false,
+	RestElement: false,  // TODO: Maybe?
+	SequenceExpression: false,
+	SpreadElement: false,  // TODO: Maybe
+	Super: false,
+	TaggedTemplateExpression: false,
+	TemplateElement: false,
+	TemplateLiteral: always,
+	ThisExpression: maybe,
+	UnaryExpression: false,
+	UpdateExpression: false,
+	YieldExpression: maybe
+};
+
+function isValidTestName(node) {
+	var fn = TEST_NAME_TYPES[node.type];
+	return (fn && fn(node)) || false;
+}
+
+// TODO: delete `false` items once we are confident they could never be a valid test function.
+var TEST_FUNCTION_TYPES = {
+	ArrayExpression: false,
+	ArrowFunctionExpression: always,
+	AssignmentExpression: function (node) {
+		return node.operator === '=' && isValidTestFunction(node.right);
+	},
+	AwaitExpression: false, // tests must be declared in the same clock tick. // CAUTION: It's deferred to ES7.
+	BinaryExpression: false,
+	CallExpression: maybe,
+	ClassExpression: false,
+	ComprehensionExpression: false,  // CAUTION: It's deferred to ES7.
+	ConditionalExpression: function (node) {
+		return and(isValidTestFunction(node.consequent), isValidTestFunction(node.alternate));
+	},
+	FunctionDeclaration: false,
+	FunctionExpression: always,
+	GeneratorExpression: false, // function *foo() {} is parsed as a FunctionExpression with node.generator == true;  // CAUTION: It's deferred to ES7.
+	Identifier: maybe,
+	Literal: false,
+	LogicalExpression: function (node) {
+		return node.operator === '||' && and(isValidTestFunction(node.left), isValidTestFunction(node.right));
+	},
+	MemberExpression: maybe,
+	NewExpression: false, // you could return a function from `new foo()` - but that's just weird
+	ObjectExpression: false,
+	RestElement: false, // TODO: Maybe?
+	SequenceExpression: false, // you could do `test((a, b, c, t => {}))` - but that's just weird
+	SpreadElement: false, // TODO: Maybe?
+	Super: false,
+	TaggedTemplateExpression: false,
+	TemplateElement: false,
+	TemplateLiteral: false,
+	ThisExpression: maybe,
+	UnaryExpression: false,
+	UpdateExpression: false,
+	YieldExpression: maybe
+};
+
+function isValidTestFunction(node) {
+	var fn = TEST_FUNCTION_TYPES[node.type];
+	return (fn && fn(node)) || false;
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,87 @@
+import test from 'ava';
+import babelEslint from 'babel-eslint';
+import utils from '../rules/utils';
+
+// isValidTestName
+
+function testName(code, expected) {
+	test(`isTestName(${code}) === $expected`, t => {
+		var node = babelEslint.parse(code).body[0].expression;
+		t.is(utils.isValidTestName(node), expected);
+	});
+}
+
+testName('"string"', 'definitely');
+testName('`template`', 'definitely');
+
+testName('callExp()', 'maybe');
+testName('this', 'maybe');
+testName('identifier', 'maybe');
+testName('obj.prop', 'maybe');
+
+test('YieldExpression is "maybe" a valid test name', t => {
+	var node = babelEslint.parse('function* foo() {yield b}').body[0].body.body[0].expression;
+	t.is(utils.isValidTestName(node), 'maybe');
+});
+
+testName('a += "str"', 'definitely');
+testName('a = "str"', 'definitely');
+testName('a += b', 'maybe');
+testName('a = b', 'maybe');
+
+testName('id1 + id2', 'maybe');
+testName('id1 + call()', 'maybe');
+testName('call() + id2', 'maybe');
+testName('call1() + call2()', 'maybe');
+testName('"str" + call2()', 'definitely');
+testName('id1 + "str"', 'definitely');
+testName('"foo" - "foo"', false);
+testName('3 + 4', false);
+
+testName('condition ? id1 : id2', 'maybe');
+testName('condition ? id1 : "string2"', 'maybe');
+testName('condition ? "string1" : "string2"', 'definitely');
+testName('condition ? 1 : "string2"', false);
+
+testName('a || b', 'maybe');
+testName('"a" || "b"', 'definitely');
+testName('a || "b"', 'maybe');
+testName('a && b', false);
+
+// isValidTestFunction
+
+function testFn(code, expected) {
+	test(`isTestFunction(${code}) === $expected`, t => {
+		var node = babelEslint.parse('(' + code + ')').body[0].expression;
+		t.is(utils.isValidTestFunction(node), expected);
+	});
+}
+
+testFn('function () {}', 'definitely');
+testFn('function foo() {}', 'definitely');
+testFn('() => {}', 'definitely');
+
+testFn('this', 'maybe');
+testFn('id', 'maybe');
+testFn('obj.prop', 'maybe');
+testFn('foo()', 'maybe');
+
+testFn('3', false);
+
+test('YieldExpression is "maybe" a valid test function', t => {
+	var node = babelEslint.parse('function* foo() {yield b}').body[0].body.body[0].expression;
+	t.is(utils.isValidTestFunction(node), 'maybe');
+});
+
+testFn('a = function () {}', 'definitely');
+testFn('a = () => {}', 'definitely');
+
+testFn('condition ? a : b', 'maybe');
+testFn('condition ? () => {} : b', 'maybe');
+testFn('condition ? () => {} : () => {}', 'definitely');
+testFn('condition ? 3 : () => {}', false);
+
+testFn('(() => {}) || (() => {})', 'definitely');
+testFn('a || (t => {})', 'maybe');
+testFn('a || function () {}', 'maybe');
+testFn('a || 3', false);


### PR DESCRIPTION
This started as something I was considering for #85 (no commented out tests).

I figured it would be good to allow users to comment out lines where they were passing arguments we knew were illegal (i.e. only a string to `test('str')` - though maybe we should tell them to uncomment it and use `todo`). 

I'm thinking maybe this has utility across some of the other rules, and could serve as the basis for an additional rule that flagged incorrect arguments to `test(...)`

Right now it's just two utility methods: `isValidTestName` and `isValidTestFunction`. Really, those could just be renamed `isString` and `isFunction` respectively, though we may go further with `isValidTestFunction` by evaluating it's parameters. 

It doesn't do much static type analysis (it never examines the scope), it just checks if it's a StringLiteral, etc.

The methods return one of `"definitely"`, `"maybe"`, or `false`. A `StringLiteral` argument is `definitely` a valid test name argument. An identifier can be anything, so it's a `maybe`. `false` is returned for constructs where we can determine the exact type, and it's the wrong one.
