### PR TITLE
Allow macro use with `test-title` rule.

### DIFF
--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -15,7 +15,7 @@ module.exports = function (context) {
 			testCount++;
 
 			var requiredLength = ava.hasTestModifier('todo') ? 1 : 2;
-			var hasNoTitle = node.arguments.length !== requiredLength;
+			var hasNoTitle = node.arguments.length < requiredLength;
 			var isOverThreshold = !ifMultiple || testCount > 1;
 
 			if (hasNoTitle && isOverThreshold) {

--- a/test/test-title.js
+++ b/test/test-title.js
@@ -64,6 +64,10 @@ test(() => {
 				code: header + 'notTest(t => { t.pass(); t.end(); });',
 				options: ['always']
 			},
+			{
+				code: header + 'test(macroFn, arg1, arg2);',
+				options: ['always']
+			},
 			// shouldn't be triggered since it's not a test file
 			{
 				code: 'test(t => {});',


### PR DESCRIPTION
Currently, the `test-title` rule will freak out if you use macros with more than one argument.

Unfotuneately, this simple fix is going to let some errors slip through. Specifically, if you don't attach a `title` function to your macro, and don't supply a string title, we probably should error, but that requires some rather involved type analysis to see if they ever did attach a title method to the macro.