### PR TITLE
Arrify the files config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "mocha"
   ],
   "dependencies": {
+    "arrify": "^1.0.1",
     "deep-strict-equal": "^0.1.0",
     "espree": "^3.1.3",
     "espurify": "^1.5.0",

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -1,5 +1,6 @@
 'use strict';
 var path = require('path');
+var arrify = require('arrify');
 var pkgUp = require('pkg-up');
 var multimatch = require('multimatch');
 var util = require('../util');
@@ -50,7 +51,7 @@ module.exports = function (context) {
 	var ava = createAvaRule();
 	var packageInfo = getPackageInfo();
 	var options = context.options[0] || {};
-	var files = options.files || packageInfo.files || defaultFiles;
+	var files = arrify(options.files || packageInfo.files || defaultFiles);
 	var hasTestCall = false;
 
 	if (!packageInfo.rootDir) {
@@ -88,7 +89,10 @@ module.exports.schema = [{
 	type: 'object',
 	properties: {
 		files: {
-			type: 'array'
+			anyOf: [
+				{type: 'array'},
+				{type: 'string'}
+			]
 		}
 	}
 }];

--- a/test/no-ignored-test-files.js
+++ b/test/no-ignored-test-files.js
@@ -129,6 +129,11 @@ test('with AVA config in package.json', () => {
 			},
 			{
 				code: code(true),
+				filename: toPath('bar/foo.test.js'),
+				options: [{files: 'bar/**/*.test.js'}]
+			},
+			{
+				code: code(true),
 				filename: '<text>',
 				options: [{files: ['lib/**/*.spec.js']}]
 			}
@@ -158,6 +163,12 @@ test('with AVA config in package.json', () => {
 				code: code(true),
 				filename: toPath('lib/foo.test.js'),
 				options: [{files: ['bar/**/*.test.js']}],
+				errors: [{message: 'Test file is ignored because it is not in `bar/**/*.test.js`.'}]
+			},
+			{
+				code: code(true),
+				filename: toPath('lib/foo.test.js'),
+				options: [{files: 'bar/**/*.test.js'}],
 				errors: [{message: 'Test file is ignored because it is not in `bar/**/*.test.js`.'}]
 			}
 		]


### PR DESCRIPTION
AVA allows you to specify a single string for `files` in `package.json`. But that can cause a TypeError in certain situations, because we don't arrify it the way AVA does.