### PR TITLE
Make test.todo message nicer

### DIFF
--- a/rules/no-todo-test.js
+++ b/rules/no-todo-test.js
@@ -12,7 +12,7 @@ module.exports = function (context) {
 			if (ava.hasTestModifier('todo')) {
 				context.report({
 					node: node,
-					message: '`test.todo()` should be not be used.'
+					message: 'Unexpected `test.todo()` stub.'
 				});
 			}
 		})


### PR DESCRIPTION
`test.todo` is more similar to [no-warning-comments](http://eslint.org/docs/rules/no-warning-comments) rather than `no-cb` or `no-skip`: in those cases, you want them to be forbidden, whereas todo means that it should be filled in. So, "should not be used" feels like the wrong language to be used here.

Open to discussion on wording, etc. Perhaps something more like "Implementation required for `test.todo()`", since the ava error that lead me to todo was ```TypeError: Expected an implementation. Use `test.todo()` for tests without an implementation.```. Bikeshed away.