### PR TITLE
Upgrade to Eslint 3 (fixes #128)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "ava": "*",
     "coveralls": "^2.11.9",
-    "eslint": "^2.2.0",
+    "eslint": "^3.0.1",
     "eslint-ava-rule-tester": "^0.1.1",
     "js-combinatorics": "^0.5.0",
     "nyc": "^6.4.0",
@@ -82,7 +82,7 @@
     "xo": "*"
   },
   "peerDependencies": {
-    "eslint": ">=2"
+    "eslint": ">=3"
   },
   "xo": {
     "esnext": true,

--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -88,7 +88,7 @@ function nbArguments(node) {
 	return false;
 }
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 	const options = context.options[0] || {};
 	const enforcesMessage = Boolean(options.message);
@@ -137,14 +137,20 @@ module.exports = context => {
 	});
 };
 
-module.exports.schema = [{
-	type: 'object',
-	properties: {
-		message: {
-			enum: [
-				'always',
-				'never'
-			]
-		}
+module.exports = {
+	create,
+	meta: {
+		docs: {},
+		schema: [{
+			type: 'object',
+			properties: {
+				message: {
+					enum: [
+						'always',
+						'never'
+					]
+				}
+			}
+		}]
 	}
-}];
+};

--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -137,20 +137,21 @@ const create = context => {
 	});
 };
 
+const schema = [{
+	type: 'object',
+	properties: {
+		message: {
+			enum: [
+				'always',
+				'never'
+			]
+		}
+	}
+}];
+
 module.exports = {
 	create,
 	meta: {
-		docs: {},
-		schema: [{
-			type: 'object',
-			properties: {
-				message: {
-					enum: [
-						'always',
-						'never'
-					]
-				}
-			}
-		}]
+		schema
 	}
 };

--- a/rules/assertion-message.js
+++ b/rules/assertion-message.js
@@ -74,15 +74,17 @@ const create = context => {
 	});
 };
 
+const schema = [{
+	enum: [
+		'always',
+		'never'
+	]
+}];
+
 module.exports = {
 	create,
 	meta: {
 		docs: {},
-		schema: [{
-			enum: [
-				'always',
-				'never'
-			]
-		}]
+		schema
 	}
 };

--- a/rules/assertion-message.js
+++ b/rules/assertion-message.js
@@ -84,7 +84,6 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
-		docs: {},
 		schema
 	}
 };

--- a/rules/assertion-message.js
+++ b/rules/assertion-message.js
@@ -34,7 +34,7 @@ function nbArguments(node) {
 	return -1;
 }
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 	const shouldHaveMessage = context.options[0] !== 'never';
 
@@ -74,9 +74,15 @@ module.exports = context => {
 	});
 };
 
-module.exports.schema = [{
-	enum: [
-		'always',
-		'never'
-	]
-}];
+module.exports = {
+	create,
+	meta: {
+		docs: {},
+		schema: [{
+			enum: [
+				'always',
+				'never'
+			]
+		}]
+	}
+};

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -4,7 +4,7 @@ const createAvaRule = require('../create-ava-rule');
 
 const notAssertionMethods = ['plan', 'end'];
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 	const maxAssertions = context.options[0] || 5;
 	let assertionCount = 0;
@@ -46,6 +46,12 @@ module.exports = context => {
 	});
 };
 
-module.exports.schema = [{
-	type: 'integer'
-}];
+module.exports = {
+	create,
+	meta: {
+		docs: {},
+		schema: [{
+			type: 'integer'
+		}]
+	}
+};

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -53,7 +53,6 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
-		docs: {},
 		schema
 	}
 };

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -46,12 +46,14 @@ const create = context => {
 	});
 };
 
+const schema = [{
+	type: 'integer'
+}];
+
 module.exports = {
 	create,
 	meta: {
 		docs: {},
-		schema: [{
-			type: 'integer'
-		}]
+		schema
 	}
 };

--- a/rules/no-cb-test.js
+++ b/rules/no-cb-test.js
@@ -21,7 +21,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/no-cb-test.js
+++ b/rules/no-cb-test.js
@@ -1,7 +1,7 @@
 'use strict';
 const createAvaRule = require('../create-ava-rule');
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -17,4 +17,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -54,7 +54,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -18,7 +18,7 @@ function isTitleUsed(usedTitleNodes, titleNode) {
 	return usedTitleNodes.some(usedTitle => deepStrictEqual(purifiedNode, usedTitle));
 }
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 	let usedTitleNodes = [];
 
@@ -50,4 +50,11 @@ module.exports = context => {
 			usedTitleNodes = [];
 		}
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -101,7 +101,6 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
-		docs: {},
 		schema
 	}
 };

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -42,7 +42,7 @@ function getPackageInfo() {
 	};
 }
 
-module.exports = context => {
+const create = context => {
 	const filename = context.getFilename();
 
 	if (filename === '<text>') {
@@ -86,14 +86,20 @@ module.exports = context => {
 	});
 };
 
-module.exports.schema = [{
-	type: 'object',
-	properties: {
-		files: {
-			anyOf: [
-				{type: 'array'},
-				{type: 'string'}
-			]
-		}
+module.exports = {
+	create,
+	meta: {
+		docs: {},
+		schema: [{
+			type: 'object',
+			properties: {
+				files: {
+					anyOf: [
+						{type: 'array'},
+						{type: 'string'}
+					]
+				}
+			}
+		}]
 	}
-}];
+};

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -86,20 +86,22 @@ const create = context => {
 	});
 };
 
+const schema = [{
+	type: 'object',
+	properties: {
+		files: {
+			anyOf: [
+				{type: 'array'},
+				{type: 'string'}
+			]
+		}
+	}
+}];
+
 module.exports = {
 	create,
 	meta: {
 		docs: {},
-		schema: [{
-			type: 'object',
-			properties: {
-				files: {
-					anyOf: [
-						{type: 'array'},
-						{type: 'string'}
-					]
-				}
-			}
-		}]
+		schema
 	}
 };

--- a/rules/no-invalid-end.js
+++ b/rules/no-invalid-end.js
@@ -24,7 +24,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/no-invalid-end.js
+++ b/rules/no-invalid-end.js
@@ -2,7 +2,7 @@
 const util = require('../util');
 const createAvaRule = require('../create-ava-rule');
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -20,4 +20,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/no-only-test.js
+++ b/rules/no-only-test.js
@@ -21,7 +21,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/no-only-test.js
+++ b/rules/no-only-test.js
@@ -1,7 +1,7 @@
 'use strict';
 const createAvaRule = require('../create-ava-rule');
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -17,4 +17,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/no-skip-assert.js
+++ b/rules/no-skip-assert.js
@@ -2,7 +2,7 @@
 const util = require('../util');
 const createAvaRule = require('../create-ava-rule');
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -19,4 +19,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/no-skip-assert.js
+++ b/rules/no-skip-assert.js
@@ -23,7 +23,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/no-skip-test.js
+++ b/rules/no-skip-test.js
@@ -21,7 +21,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/no-skip-test.js
+++ b/rules/no-skip-test.js
@@ -1,7 +1,7 @@
 'use strict';
 const createAvaRule = require('../create-ava-rule');
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -17,4 +17,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/no-statement-after-end.js
+++ b/rules/no-statement-after-end.js
@@ -13,7 +13,7 @@ const isEndExpression = node =>
 	node.callee.property.type === 'Identifier' &&
 	node.callee.property.name === 'end';
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 	const segmentInfoMap = Object.create(null);
 	const segmentInfoStack = [];
@@ -87,4 +87,11 @@ module.exports = context => {
 		onCodePathSegmentEnd: segmentEnd,
 		CallExpression: checkForEndExpression
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/no-statement-after-end.js
+++ b/rules/no-statement-after-end.js
@@ -91,7 +91,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/no-todo-test.js
+++ b/rules/no-todo-test.js
@@ -21,7 +21,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/no-todo-test.js
+++ b/rules/no-todo-test.js
@@ -1,7 +1,7 @@
 'use strict';
 const createAvaRule = require('../create-ava-rule');
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -17,4 +17,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/no-unknown-modifiers.js
+++ b/rules/no-unknown-modifiers.js
@@ -30,7 +30,7 @@ function getTestModifiers(node) {
 const unknownModifiers = node => getTestModifiers(node)
 	.filter(modifier => modifiers.indexOf(modifier) === -1);
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -48,4 +48,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/no-unknown-modifiers.js
+++ b/rules/no-unknown-modifiers.js
@@ -52,7 +52,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -52,7 +52,7 @@ const isCalleeMatched = (callee, methodName) =>
 	deepStrictEqual(callee, assertionCalleeAst(methodName)) ||
 	deepStrictEqual(callee, skippedAssertionCalleeAst(methodName));
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -74,4 +74,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -78,7 +78,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/test-ended.js
+++ b/rules/test-ended.js
@@ -41,8 +41,6 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
-		docs: {},
-		schema: [{
-		}]
+		docs: {}
 	}
 };

--- a/rules/test-ended.js
+++ b/rules/test-ended.js
@@ -40,7 +40,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/test-ended.js
+++ b/rules/test-ended.js
@@ -1,7 +1,7 @@
 'use strict';
 const createAvaRule = require('../create-ava-rule');
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 	let endCalled = false;
 
@@ -36,4 +36,13 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {},
+		schema: [{
+		}]
+	}
 };

--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -1,7 +1,7 @@
 'use strict';
 const createAvaRule = require('../create-ava-rule');
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 	const ifMultiple = context.options[0] !== 'always';
 	let testCount = 0;
@@ -31,9 +31,15 @@ module.exports = context => {
 	});
 };
 
-module.exports.schema = [{
-	enum: [
-		'always',
-		'if-multiple'
-	]
-}];
+module.exports = {
+	create,
+	meta: {
+		docs: {},
+		schema: [{
+			enum: [
+				'always',
+				'if-multiple'
+			]
+		}]
+	}
+};

--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -31,15 +31,17 @@ const create = context => {
 	});
 };
 
+const schema = [{
+	enum: [
+		'always',
+		'if-multiple'
+	]
+}];
+
 module.exports = {
 	create,
 	meta: {
 		docs: {},
-		schema: [{
-			enum: [
-				'always',
-				'if-multiple'
-			]
-		}]
+		schema
 	}
 };

--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -41,7 +41,6 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
-		docs: {},
 		schema
 	}
 };

--- a/rules/use-t-well.js
+++ b/rules/use-t-well.js
@@ -58,7 +58,7 @@ const getMemberStats = members => {
 	}, initial);
 };
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -129,4 +129,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/use-t-well.js
+++ b/rules/use-t-well.js
@@ -133,7 +133,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/use-t.js
+++ b/rules/use-t.js
@@ -32,7 +32,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/use-t.js
+++ b/rules/use-t.js
@@ -1,7 +1,7 @@
 'use strict';
 const createAvaRule = require('../create-ava-rule');
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -28,4 +28,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/use-test.js
+++ b/rules/use-test.js
@@ -38,7 +38,5 @@ const create = context => ({
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };

--- a/rules/use-test.js
+++ b/rules/use-test.js
@@ -23,7 +23,7 @@ function report(context, node) {
 	});
 }
 
-module.exports = context => ({
+const create = context => ({
 	ImportDeclaration: node => {
 		if (node.source.value === 'ava' && node.specifiers[0].local.name !== 'test') {
 			report(context, node);
@@ -35,3 +35,10 @@ module.exports = context => ({
 		}
 	}
 });
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
+};

--- a/rules/use-true-false.js
+++ b/rules/use-true-false.js
@@ -45,7 +45,7 @@ function matchesKnownBooleanExpression(arg) {
 	return knownBooleanSignatures.some(signature => deepStrictEqual(callee, signature));
 }
 
-module.exports = context => {
+const create = context => {
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -81,4 +81,11 @@ module.exports = context => {
 			}
 		})
 	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {}
+	}
 };

--- a/rules/use-true-false.js
+++ b/rules/use-true-false.js
@@ -85,7 +85,5 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {
-		docs: {}
-	}
+	meta: {}
 };


### PR DESCRIPTION
Upgrade to Eslint 3 (fixes #128)

I didn't use the migration tool in the end as it adds spaces everywhere and destroys the indentation we had. It also indented the main rule function which was not needed.

I think that we could add a `recommended` setting and generate the recommended settings that way. Would remove a lot of boilerplate in addition to what has been done using `req-all`. I'll leave that for later.

Let me know if I've missed anything.