### PR TITLE
Fix no-async-fn-without-await when used with default parser (fixes #147)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ava": "*",
     "babel-eslint": "^6.1.2",
     "coveralls": "^2.11.9",
-    "eslint": "^3.0.1",
+    "eslint": "^3.7.1",
     "eslint-ava-rule-tester": "^2.0.0",
     "js-combinatorics": "^0.5.0",
     "nyc": "^7.1.0",

--- a/rules/no-async-fn-without-await.js
+++ b/rules/no-async-fn-without-await.js
@@ -7,6 +7,12 @@ const create = context => {
 	let testIsAsync = false;
 	let testUsed = false;
 
+	const registerUseOfAwait = () => {
+		if (testIsAsync) {
+			testUsed = true;
+		}
+	};
+
 	return ava.merge({
 		CallExpression: visitIf([
 			ava.isInTestFile,
@@ -15,11 +21,8 @@ const create = context => {
 			const implementationFn = node.arguments[0];
 			testIsAsync = implementationFn && implementationFn.async;
 		}),
-		YieldExpression: () => {
-			if (testIsAsync) {
-				testUsed = true;
-			}
-		},
+		AwaitExpression: registerUseOfAwait,
+		YieldExpression: registerUseOfAwait,
 		'CallExpression:exit': visitIf([
 			ava.isInTestFile,
 			ava.isTestNode

--- a/test/no-async-fn-without-await.js
+++ b/test/no-async-fn-without-await.js
@@ -2,52 +2,64 @@ import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
 import rule from '../rules/no-async-fn-without-await';
 
-const ruleTester = avaRuleTester(test, {
-	parser: 'babel-eslint',
-	env: {
-		es6: true
-	}
-});
-
 const error = {
 	ruleId: 'no-async-fn-without-await',
 	message: 'Function was declared as `async` but doesn\'t use `await`'
 };
 const header = `const test = require('ava');\n`;
 
-ruleTester.run('no-async-fn-without-await', rule, {
-	valid: [
-		`${header} test(fn);`,
-		`${header} test(t => {});`,
-		`${header} test(function(t) {});`,
-		`${header} test(async t => { await foo(); });`,
-		`${header} test(async t => { t.is(await foo(), 1); });`,
-		`${header} test(async function(t) { await foo(); });`,
-		`${header} test(async t => { if (bar) { await foo(); } });`,
-		`${header} test(async t => { if (bar) {} else { await foo(); } });`,
-		// shouldn't be triggered since it's not a test file
-		'test(async t => {});'
-	],
-	invalid: [
-		{
-			code: `${header} test(async t => {});`,
-			errors: [error]
-		},
-		{
-			code: `${header} test(async function(t) {});`,
-			errors: [error]
-		},
-		{
-			code: `${header} test(async t => {}); test(async t => {});`,
-			errors: [error, error]
-		},
-		{
-			code: `${header} test(async t => {}); test(async t => { await foo(); });`,
-			errors: [error]
-		},
-		{
-			code: `${header} test(async t => { await foo(); }); test(async t => {});`,
-			errors: [error]
+const ruleTesterOptions = [
+	{
+		parserOptions: {
+			ecmaVersion: 2017
 		}
-	]
+	},
+	{
+		parser: 'babel-eslint',
+		env: {
+			es6: true
+		}
+	}
+];
+
+ruleTesterOptions.forEach(options => {
+	const ruleTester = avaRuleTester(test, options);
+
+	ruleTester.run(`no-async-fn-without-await`, rule, {
+		valid: [
+			`${header} test(fn);`,
+			`${header} test(t => {});`,
+			`${header} test(function(t) {});`,
+			`${header} test(async t => { await foo(); });`,
+			`${header} test(async t => { t.is(await foo(), 1); });`,
+			`${header} test(async function(t) { await foo(); });`,
+			`${header} test(async t => { if (bar) { await foo(); } });`,
+			`${header} test(async t => { if (bar) {} else { await foo(); } });`,
+			`${header} test.after(async () => { await foo(); });`,
+			// shouldn't be triggered since it's not a test file
+			'test(async t => {});'
+		],
+		invalid: [
+			{
+				code: `${header} test(async t => {});`,
+				errors: [error]
+			},
+			{
+				code: `${header} test(async function(t) {});`,
+				errors: [error]
+			},
+			{
+				code: `${header} test(async t => {}); test(async t => {});`,
+				errors: [error, error]
+			},
+			{
+				code: `${header} test(async t => {}); test(async t => { await foo(); });`,
+				errors: [error]
+			},
+			{
+				code: `${header} test(async t => { await foo(); }); test(async t => {});`,
+				errors: [error]
+			}
+		]
+	});
 });


### PR DESCRIPTION
Fix no-async-fn-without-await when used with default parser (fixes #147)

Espree supports async/await, but it doesn't generate the same AST as babel-eslint when using async/await. Espree uses a `AwaitExpression` node (which makes ore sense IMO), while `babel-eslint` uses `YieldExpression` (which I think could give incorrect results when using the generator `yield` keyword).

The test file looks like it's been rewritten, but I just indented the whole test suite, to be able to use it with both parsers (I've added one test, and that's it).

The tests fail because of XO, I'll do that in another PR real quick.
EDIT: Done in #149. Tests for this PR should be re-run after it gets merged.