### PR TITLE
Set `ecmaVersion` to `2017`

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
 				es6: true
 			},
 			parserOptions: {
-				ecmaVersion: 7,
+				ecmaVersion: 2017,
 				sourceType: 'module'
 			},
 			rules: {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "xo": "*"
   },
   "peerDependencies": {
-    "eslint": ">=3"
+    "eslint": ">=3.6"
   },
   "xo": {
     "esnext": true,


### PR DESCRIPTION
Probably a reason you haven't done it yet (other than the fact it's a breaking change), but it's annoying having ava override our setting just because we want to use recommended config, which means we have to specify `ecmaVersion` multiple places (as we only have ava in test dirs)

An idea might be to drop the version entirely from recommended? That's still breaking, though.

Could do `require('eslint/package.json').version` and check if it's new enough to keep it non-breaking?
