### PR TITLE
Fix `no-async-without-fn` when using a title

### DIFF
--- a/rules/no-async-fn-without-await.js
+++ b/rules/no-async-fn-without-await.js
@@ -13,13 +13,14 @@ const create = context => {
 		}
 	};
 
+	const isAsync = node => Boolean(node && node.async);
+
 	return ava.merge({
 		CallExpression: visitIf([
 			ava.isInTestFile,
 			ava.isTestNode
 		])(node => {
-			const implementationFn = node.arguments[0];
-			testIsAsync = implementationFn && implementationFn.async;
+			testIsAsync = isAsync(node.arguments[0]) || isAsync(node.arguments[1]);
 		}),
 		AwaitExpression: registerUseOfAwait,
 		YieldExpression: registerUseOfAwait,

--- a/test/no-async-fn-without-await.js
+++ b/test/no-async-fn-without-await.js
@@ -36,6 +36,9 @@ ruleTesterOptions.forEach(options => {
 			`${header} test(async t => { if (bar) { await foo(); } });`,
 			`${header} test(async t => { if (bar) {} else { await foo(); } });`,
 			`${header} test.after(async () => { await foo(); });`,
+			`${header} test('title', fn);`,
+			`${header} test('title', function(t) {});`,
+			`${header} test('title', async t => { await foo(); });`,
 			// shouldn't be triggered since it's not a test file
 			'test(async t => {});'
 		],
@@ -58,6 +61,10 @@ ruleTesterOptions.forEach(options => {
 			},
 			{
 				code: `${header} test(async t => { await foo(); }); test(async t => {});`,
+				errors: [error]
+			},
+			{
+				code: `${header} test('title', async t => {});`,
 				errors: [error]
 			}
 		]


### PR DESCRIPTION
Fixes #160: Fixes `no-async-without-fn` not reporting anything when not using a title.

I decided to simply check if any of the first two arguments is a async. I thought about writing a function that finds the implementation function among the arguments, but that can be rather tricky when using identifiers.

```js
function implementationFn(t, argFunction) {
  t.throws(argFunction(1));
}
implementationFn.title = 'foo'
test(implementationFn, async n => {}); // We'd probably assume the second function is the implementation function, but no.
```

This could create false positives in the case shown above, if that function also does not contain `async`. Sounds like an extreme edge case, and they should not mark it as async anyway IMO, so it should be fine.