### PR TITLE
Allow passing an argument to `t.end()` (fixes #164)

### DIFF
--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -8,10 +8,6 @@ const expectedNbArguments = {
 		min: 2,
 		max: 3
 	},
-	end: {
-		min: 0,
-		max: 0
-	},
 	fail: {
 		min: 0,
 		max: 1
@@ -74,21 +70,6 @@ const expectedNbArguments = {
 	}
 };
 
-function nbArguments(node) {
-	const name = node.property.name;
-	const nArgs = expectedNbArguments[name];
-
-	if (nArgs) {
-		return nArgs;
-	}
-
-	if (node.object.type === 'MemberExpression') {
-		return nbArguments(node.object);
-	}
-
-	return false;
-}
-
 const create = context => {
 	const ava = createAvaRule();
 	const options = context.options[0] || {};
@@ -115,7 +96,18 @@ const create = context => {
 			}
 
 			const gottenArgs = node.arguments.length;
-			const nArgs = nbArguments(callee);
+			const members = util.getMembers(callee)
+				.filter(name => name !== 'skip');
+
+			if (members[0] === 'end') {
+				if (gottenArgs > 1) {
+					report(node, `Too many arguments. Expected at most 1.`);
+				}
+
+				return;
+			}
+
+			const nArgs = expectedNbArguments[members[0]];
 
 			if (!nArgs) {
 				return;

--- a/test/assertion-arguments.js
+++ b/test/assertion-arguments.js
@@ -35,7 +35,6 @@ function testCase(message, content, errorMessage, useHeader) {
 ruleTester.run('assertion-arguments', rule, {
 	valid: [
 		testCase(false, `t.plan(1);`),
-		testCase(false, `t.end();`),
 		testCase(false, `t.deepEqual({}, {}, 'message');`),
 		testCase(false, `t.fail('message');`),
 		testCase(false, `t.false(false, 'message');`),
@@ -82,7 +81,6 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, `t.foo(1, 2, 3, 4);`),
 
 		testCase('always', `t.plan(1);`),
-		testCase('always', `t.end();`),
 		testCase('always', `t.pass('message');`),
 		testCase('always', `t.fail('message');`),
 		testCase('always', `t.truthy('unicorn', 'message');`),
@@ -108,7 +106,6 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('always', `t.foo(1, 2, 3, 4);`),
 
 		testCase('never', `t.plan(1);`),
-		testCase('never', `t.end();`),
 		testCase('never', `t.pass();`),
 		testCase('never', `t.fail();`),
 		testCase('never', `t.truthy('unicorn');`),
@@ -132,7 +129,27 @@ ruleTester.run('assertion-arguments', rule, {
 
 		testCase('never', `t.context.a(1, 2, 3, 4);`),
 		testCase('never', `t.context.is(1, 2, 3, 4);`),
-		testCase('never', `t.foo(1, 2, 3, 4);`)
+		testCase('never', `t.foo(1, 2, 3, 4);`),
+
+		// Special case for `t.end()``
+		testCase(false, `t.end();`),
+		testCase(false, `t.end(error);`),
+		testCase(false, `t.end.skip();`),
+		testCase(false, `t.end.skip(error);`),
+		testCase(false, `t.skip.end();`),
+		testCase(false, `t.skip.end(error);`),
+		testCase('always', `t.end();`),
+		testCase('always', `t.end(error);`),
+		testCase('always', `t.end.skip();`),
+		testCase('always', `t.end.skip(error);`),
+		testCase('always', `t.skip.end();`),
+		testCase('always', `t.skip.end(error);`),
+		testCase('never', `t.end();`),
+		testCase('never', `t.end(error);`),
+		testCase('never', `t.end.skip();`),
+		testCase('never', `t.end.skip(error);`),
+		testCase('never', `t.skip.end();`),
+		testCase('never', `t.skip.end(error);`)
 	],
 	invalid: [
 		// Not enough arguments
@@ -155,7 +172,6 @@ ruleTester.run('assertion-arguments', rule, {
 
 		// Too many arguments
 		testCase(false, `t.plan(1, 'extra argument');`, tooManyError(1)),
-		testCase(false, `t.end('extra argument');`, tooManyError(0)),
 		testCase(false, `t.pass('message', 'extra argument');`, tooManyError(1)),
 		testCase(false, `t.fail('message', 'extra argument');`, tooManyError(1)),
 		testCase(false, `t.truthy('unicorn', 'message', 'extra argument');`, tooManyError(2)),
@@ -209,6 +225,10 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('never', `t.notRegex(a, /a/, 'message');`, foundError),
 		testCase('never', `t.ifError(new Error(), 'message');`, foundError),
 		testCase('never', `t.skip.is('same', 'same', 'message');`, foundError),
-		testCase('never', `t.is.skip('same', 'same', 'message');`, foundError)
+		testCase('never', `t.is.skip('same', 'same', 'message');`, foundError),
+
+		testCase(false, `t.end('too many', 'arguments');`, tooManyError(1)),
+		testCase(false, `t.skip.end('too many', 'arguments');`, tooManyError(1)),
+		testCase(false, `t.end.skip('too many', 'arguments');`, tooManyError(1))
 	]
 });


### PR DESCRIPTION
Allow passing an argument to `t.end()` (fixes #164)

`t.end()` is now a special case for this rule, as the optional argument it allows is not a message that we'd like to enforce based on the `message` option.

I've simplified the implementation a bit by re-using `util.getMembers`.