### PR TITLE
Support t.snapshot()

### DIFF
--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -56,6 +56,10 @@ const expectedNbArguments = {
 		min: 2,
 		max: 3
 	},
+	snapshot: {
+		min: 1,
+		max: 2
+	},
 	throws: {
 		min: 1,
 		max: 3

--- a/test/assertion-arguments.js
+++ b/test/assertion-arguments.js
@@ -52,6 +52,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, `t.throws(Promise.reject(), Error, 'message');`),
 		testCase(false, `t.true(true, 'message');`),
 		testCase(false, `t.truthy('unicorn', 'message');`),
+		testCase(false, `t.snapshot(value, 'message');`),
 		// shouldn't be triggered since it's not a test file
 		testCase(false, `t.true(true);`, false, false),
 
@@ -73,6 +74,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, `t.throws(Promise.reject(), Error);`),
 		testCase(false, `t.true(true);`),
 		testCase(false, `t.truthy('unicorn');`),
+		testCase(false, `t.snapshot(value);`),
 		// shouldn't be triggered since it's not a test file
 		testCase(false, `t.true(true, 'message');`, [], false),
 
@@ -98,6 +100,8 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('always', `t.ifError(new Error(), 'message');`),
 		testCase('always', `t.skip.is('same', 'same', 'message');`),
 		testCase('always', `t.is.skip('same', 'same', 'message');`),
+		testCase('always', `t.snapshot(value, 'message');`),
+
 		// shouldn't be triggered since it's not a test file
 		testCase('always', `t.true(true);`, [], false),
 
@@ -124,6 +128,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('never', `t.ifError(new Error());`),
 		testCase('never', `t.skip.is('same', 'same');`),
 		testCase('never', `t.is.skip('same', 'same');`),
+		testCase('never', `t.snapshot(value);`),
 		// shouldn't be triggered since it's not a test file
 		testCase('never', `t.true(true, 'message');`, [], false),
 
@@ -169,6 +174,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, `t.ifError();`, tooFewError(1)),
 		testCase(false, `t.skip.is('same');`, tooFewError(2)),
 		testCase(false, `t.is.skip('same');`, tooFewError(2)),
+		testCase(false, `t.snapshot();`, tooFewError(1)),
 
 		// Too many arguments
 		testCase(false, `t.plan(1, 'extra argument');`, tooManyError(1)),
@@ -189,6 +195,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, `t.ifError(new Error(), 'message', 'extra argument');`, tooManyError(2)),
 		testCase(false, `t.skip.is('same', 'same', 'message', 'extra argument');`, tooManyError(3)),
 		testCase(false, `t.is.skip('same', 'same', 'message', 'extra argument');`, tooManyError(3)),
+		testCase(false, `t.snapshot(value, 'message', 'extra argument');`, tooManyError(2)),
 
 		testCase('always', `t.pass();`, missingError),
 		testCase('always', `t.fail();`, missingError),
@@ -208,6 +215,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('always', `t.ifError(new Error());`, missingError),
 		testCase('always', `t.skip.is('same', 'same');`, missingError),
 		testCase('always', `t.is.skip('same', 'same');`, missingError),
+		testCase('always', `t.snapshot(value);`, missingError),
 
 		testCase('never', `t.pass('message');`, foundError),
 		testCase('never', `t.fail('message');`, foundError),
@@ -226,6 +234,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('never', `t.ifError(new Error(), 'message');`, foundError),
 		testCase('never', `t.skip.is('same', 'same', 'message');`, foundError),
 		testCase('never', `t.is.skip('same', 'same', 'message');`, foundError),
+		testCase('never', `t.snapshot(value, 'message');`, foundError),
 
 		testCase(false, `t.end('too many', 'arguments');`, tooManyError(1)),
 		testCase(false, `t.skip.end('too many', 'arguments');`, tooManyError(1)),

--- a/test/no-duplicate-modifiers.js
+++ b/test/no-duplicate-modifiers.js
@@ -28,10 +28,9 @@ const modifiers = [
 const valid = modifiers.map(modifier => `${header} test.${modifier}(t => {});`);
 const invalid = modifiers.map(modifier => ({
 	code: `${header} test.${modifier}.${modifier}(t => {});`,
-	errors: [{
-		...ruleError,
-		message: `Duplicate test modifier \`${modifier}\`.`
-	}]
+	errors: [
+		Object.assign({}, ruleError, {message: `Duplicate test modifier \`${modifier}\`.`})
+	]
 }));
 
 ruleTester.run('no-duplicate-modifiers', rule, {
@@ -48,10 +47,7 @@ ruleTester.run('no-duplicate-modifiers', rule, {
 		{
 			code: `${header} test.serial.cb.only.serial(t => {});`,
 			errors: [
-				{
-					...ruleError,
-					message: 'Duplicate test modifier `serial`.'
-				}
+				Object.assign({}, ruleError, {message: 'Duplicate test modifier `serial`.'})
 			]
 		}
 	])

--- a/test/no-unknown-modifiers.js
+++ b/test/no-unknown-modifiers.js
@@ -11,6 +11,10 @@ const ruleTester = avaRuleTester(test, {
 const ruleError = {ruleId: 'no-unknown-modifiers'};
 const header = `const test = require('ava');\n`;
 
+function error(message) {
+	return Object.assign({}, ruleError, {message});
+}
+
 ruleTester.run('no-unknown-modifiers', rule, {
 	valid: [
 		`${header} test(t => {});`,
@@ -33,75 +37,35 @@ ruleTester.run('no-unknown-modifiers', rule, {
 	invalid: [
 		{
 			code: `${header} test.foo(t => {});`,
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown test modifier `foo`.'
-				}
-			]
+			errors: [error('Unknown test modifier `foo`.')]
 		},
 		{
 			code: `${header} test.onlu(t => {});`,
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown test modifier `onlu`.'
-				}
-			]
+			errors: [error('Unknown test modifier `onlu`.')]
 		},
 		{
 			code: `${header} test.beforeeach(t => {});`,
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown test modifier `beforeeach`.'
-				}
-			]
+			errors: [error('Unknown test modifier `beforeeach`.')]
 		},
 		{
 			code: `${header} test.c.only(t => {});`,
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown test modifier `c`.'
-				}
-			]
+			errors: [error('Unknown test modifier `c`.')]
 		},
 		{
 			code: `${header} test.cb.onlu(t => {});`,
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown test modifier `onlu`.'
-				}
-			]
+			errors: [error('Unknown test modifier `onlu`.')]
 		},
 		{
 			code: `${header} test.foo.bar.baz(t => {});`,
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown test modifier `foo`.'
-				}
-			]
+			errors: [error('Unknown test modifier `foo`.')]
 		},
 		{
 			code: `${header} test.default(t => {});`,
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown test modifier `default`.'
-				}
-			]
+			errors: [error('Unknown test modifier `default`.')]
 		},
 		{
 			code: `${header} test.test(t => {});`,
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown test modifier `test`.'
-				}
-			]
+			errors: [error('Unknown test modifier `test`.')]
 		}
 	]
 });

--- a/test/use-t-well.js
+++ b/test/use-t-well.js
@@ -11,6 +11,10 @@ const ruleTester = avaRuleTester(test, {
 const ruleError = {ruleId: 'use-t-well'};
 const header = `const test = require('ava');\n`;
 
+function error(message) {
+	return Object.assign({}, ruleError, {message});
+}
+
 function testCase(contents, prependHeader) {
 	const content = `test(t => { ${contents} });`;
 
@@ -56,119 +60,55 @@ ruleTester.run('use-t-well', rule, {
 	invalid: [
 		{
 			code: testCase('t();'),
-			errors: [
-				{
-					...ruleError,
-					message: '`t` is not a function.'
-				}
-			]
+			errors: [error('`t` is not a function.')]
 		},
 		{
 			code: testCase('t.foo(a, a);'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown assertion method `foo`.'
-				}
-			]
+			errors: [error('Unknown assertion method `foo`.')]
 		},
 		{
 			code: testCase('t.depEqual(a, a);'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown assertion method `depEqual`.'
-				}
-			]
+			errors: [error('Unknown assertion method `depEqual`.')]
 		},
 		{
 			code: testCase('t.deepEqual.skp(a, a);'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown assertion method `skp`.'
-				}
-			]
+			errors: [error('Unknown assertion method `skp`.')]
 		},
 		{
 			code: testCase('t.skp.deepEqual(a, a);'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown assertion method `skp`.'
-				}
-			]
+			errors: [error('Unknown assertion method `skp`.')]
 		},
 		{
 			code: testCase('t.context();'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown assertion method `context`.'}
-			]
+			errors: [error('Unknown assertion method `context`.')]
 		},
 		{
 			code: testCase('t.a = 1;'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown member `a`. Use `context.a` instead.'
-				}
-			]
+			errors: [error('Unknown member `a`. Use `context.a` instead.')]
 		},
 		{
 			code: testCase('t.ctx.a = 1;'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown member `ctx`. Use `context.ctx` instead.'
-				}
-			]
+			errors: [error('Unknown member `ctx`. Use `context.ctx` instead.')]
 		},
 		{
 			code: testCase('t.deepEqu;'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown member `deepEqu`. Use `context.deepEqu` instead.'
-				}
-			]
+			errors: [error('Unknown member `deepEqu`. Use `context.deepEqu` instead.')]
 		},
 		{
 			code: testCase('t.deepEqual.is(a, a);'),
-			errors: [
-				{
-					...ruleError,
-					message: `Can't chain assertion methods.`
-				}
-			]
+			errors: [error(`Can't chain assertion methods.`)]
 		},
 		{
 			code: testCase('t.paln(1);'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Unknown assertion method `paln`.'
-				}
-			]
+			errors: [error('Unknown assertion method `paln`.')]
 		},
 		{
 			code: testCase('t.skip();'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Missing assertion method.'
-				}
-			]
+			errors: [error('Missing assertion method.')]
 		},
 		{
 			code: testCase('t.deepEqual.skip.skip(a, a);'),
-			errors: [
-				{
-					...ruleError,
-					message: 'Too many chained uses of `skip`.'
-				}
-			]
+			errors: [error('Too many chained uses of `skip`.')]
 		}
 	]
 });

--- a/test/use-t-well.js
+++ b/test/use-t-well.js
@@ -44,6 +44,7 @@ ruleTester.run('use-t-well', rule, {
 		testCase('t.notThrows(fn);'),
 		testCase('t.regex(v, /v/);'),
 		testCase('t.notRegex(v, /v/);'),
+		testCase('t.snapshot(v);'),
 		testCase('t.ifError(error);'),
 		testCase('t.deepEqual.skip(a, a);'),
 		testCase('t.skip.deepEqual(a, a);'),

--- a/util.js
+++ b/util.js
@@ -78,6 +78,7 @@ const assertionMethodsNumArguments = new Map([
 	['pass', 0],
 	['regex', 2],
 	['notRegex', 2],
+	['snapshot', 1],
 	['throws', 1],
 	['true', 1],
 	['truthy', 1]


### PR DESCRIPTION
Fixes #169: Support `t.snapshot()`

I also added a commit to remove the use of `...` object assign operator as it's not supported out of the box in AVA 0.18 anymore.