### PR TITLE
(#168) no-identical-title: Do not report identical titles when using macros

### DIFF
--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -2,6 +2,7 @@
 const espurify = require('espurify');
 const visitIf = require('enhance-visitors').visitIf;
 const deepStrictEqual = require('deep-strict-equal');
+const util = require('../util');
 const createAvaRule = require('../create-ava-rule');
 
 const purify = node => node && espurify(node);
@@ -34,6 +35,11 @@ const create = context => {
 
 			// don't flag computed titles or anonymous tests (anon tests covered in the if-multiple rule)
 			if (titleNode === undefined || !isStatic(titleNode)) {
+				return;
+			}
+
+			// Don't flag what look to be macros
+			if (args.length > 2 && !util.isFunctionExpression(args[1])) {
 				return;
 			}
 

--- a/test/no-identical-title.js
+++ b/test/no-identical-title.js
@@ -32,6 +32,25 @@ ruleTester.run('no-identical-title', rule, {
 		// multiple anonymous tests covered by the if-multiple rule
 		header + 'test(t => {}); test(t => {});',
 		header + 'test(t => {}); test.cb(t => {});',
+		// macros
+		` ${header}
+			const macro = (t, value) => { t.true(value); };
+
+			test(macro, true);
+			test(macro, false);
+		`,
+		` ${header}
+			const macro = (t, value) => { t.true(value); };
+
+			test('should work', macro, true);
+			test('should fail', macro, false);
+		`,
+		` ${header}
+			const macro = (t, value) => { t.true(value); };
+
+			test('same title', macro, true);
+			test('same title', macro, false);
+		`,
 		// shouldn't be triggered since it's not a test file
 		'test(t => {}); test(t => {});',
 		'test("a", t => {}); test("a", t => {});'


### PR DESCRIPTION
Fixes #168, no-identical-title: Do not report identical titles when using macros

cc @novemberborn 