### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -149,6 +149,9 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/assertion-arguments.md'
+		},
 		schema
 	}
 };

--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -150,7 +150,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/assertion-arguments.md'
+			url: util.getDocsUrl()
 		},
 		schema
 	}

--- a/rules/assertion-message.js
+++ b/rules/assertion-message.js
@@ -68,7 +68,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/assertion-message.md'
+			url: 'https://github.com/avajs/eslint-plugin-ava/blob/4211212daf1bfcfff3ebc5d4efdc4ba1a87acbf1/docs/rules/assertion-message.md'
 		},
 		schema,
 		deprecated: true

--- a/rules/assertion-message.js
+++ b/rules/assertion-message.js
@@ -68,7 +68,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/blob/4211212daf1bfcfff3ebc5d4efdc4ba1a87acbf1/docs/rules/assertion-message.md'
+			url: util.getDocsUrl('assertion-message', '4211212daf1bfcfff3ebc5d4efdc4ba1a87acbf1')
 		},
 		schema,
 		deprecated: true

--- a/rules/assertion-message.js
+++ b/rules/assertion-message.js
@@ -67,6 +67,9 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/assertion-message.md'
+		},
 		schema,
 		deprecated: true
 	}

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -61,6 +61,9 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/max-asserts.md'
+		},
 		schema
 	}
 };

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -62,7 +62,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/max-asserts.md'
+			url: util.getDocsUrl()
 		},
 		schema
 	}

--- a/rules/no-async-fn-without-await.js
+++ b/rules/no-async-fn-without-await.js
@@ -48,5 +48,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-async-fn-without-await.md'
+		}
+	}
 };

--- a/rules/no-async-fn-without-await.js
+++ b/rules/no-async-fn-without-await.js
@@ -1,6 +1,7 @@
 'use strict';
 const visitIf = require('enhance-visitors').visitIf;
 const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
 
 const create = context => {
 	const ava = createAvaRule();
@@ -50,7 +51,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-async-fn-without-await.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-cb-test.js
+++ b/rules/no-cb-test.js
@@ -25,7 +25,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-cb-test.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-cb-test.js
+++ b/rules/no-cb-test.js
@@ -23,5 +23,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-cb-test.md'
+		}
+	}
 };

--- a/rules/no-duplicate-modifiers.js
+++ b/rules/no-duplicate-modifiers.js
@@ -44,5 +44,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-duplicate-modifiers.md'
+		}
+	}
 };

--- a/rules/no-duplicate-modifiers.js
+++ b/rules/no-duplicate-modifiers.js
@@ -46,7 +46,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-duplicate-modifiers.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -61,5 +61,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-identical-title.md'
+		}
+	}
 };

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -63,7 +63,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-identical-title.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -103,7 +103,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-ignored-test-files.md'
+			url: util.getDocsUrl()
 		},
 		schema
 	}

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -102,6 +102,9 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-ignored-test-files.md'
+		},
 		schema
 	}
 };

--- a/rules/no-invalid-end.js
+++ b/rules/no-invalid-end.js
@@ -25,5 +25,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-invalid-end.md'
+		}
+	}
 };

--- a/rules/no-invalid-end.js
+++ b/rules/no-invalid-end.js
@@ -27,7 +27,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-invalid-end.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-nested-tests.js
+++ b/rules/no-nested-tests.js
@@ -1,6 +1,7 @@
 'use strict';
 const visitIf = require('enhance-visitors').visitIf;
 const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
 
 const create = context => {
 	const ava = createAvaRule();
@@ -33,7 +34,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-nested-tests.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-nested-tests.js
+++ b/rules/no-nested-tests.js
@@ -31,5 +31,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-nested-tests.md'
+		}
+	}
 };

--- a/rules/no-only-test.js
+++ b/rules/no-only-test.js
@@ -32,6 +32,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-only-test.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-only-test.js
+++ b/rules/no-only-test.js
@@ -33,7 +33,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-only-test.md'
+			url: util.getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/no-skip-assert.js
+++ b/rules/no-skip-assert.js
@@ -24,5 +24,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-skip-assert.md'
+		}
+	}
 };

--- a/rules/no-skip-assert.js
+++ b/rules/no-skip-assert.js
@@ -26,7 +26,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-skip-assert.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-skip-test.js
+++ b/rules/no-skip-test.js
@@ -33,7 +33,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-skip-test.md'
+			url: util.getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/no-skip-test.js
+++ b/rules/no-skip-test.js
@@ -32,6 +32,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-skip-test.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-statement-after-end.js
+++ b/rules/no-statement-after-end.js
@@ -1,5 +1,6 @@
 'use strict';
 const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
 
 // This rule makes heavy use of eslints code path analysis
 // See: http://eslint.org/docs/developer-guide/code-path-analysis.html
@@ -93,7 +94,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-statement-after-end.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-statement-after-end.js
+++ b/rules/no-statement-after-end.js
@@ -91,5 +91,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-statement-after-end.md'
+		}
+	}
 };

--- a/rules/no-todo-implementation.js
+++ b/rules/no-todo-implementation.js
@@ -23,5 +23,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-todo-implementation.md'
+		}
+	}
 };

--- a/rules/no-todo-implementation.js
+++ b/rules/no-todo-implementation.js
@@ -25,7 +25,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-todo-implementation.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-todo-test.js
+++ b/rules/no-todo-test.js
@@ -1,6 +1,7 @@
 'use strict';
 const visitIf = require('enhance-visitors').visitIf;
 const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
 
 const create = context => {
 	const ava = createAvaRule();
@@ -24,7 +25,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-todo-test.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/no-todo-test.js
+++ b/rules/no-todo-test.js
@@ -22,5 +22,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-todo-test.md'
+		}
+	}
 };

--- a/rules/no-unknown-modifiers.js
+++ b/rules/no-unknown-modifiers.js
@@ -42,5 +42,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-unknown-modifiers.md'
+		}
+	}
 };

--- a/rules/no-unknown-modifiers.js
+++ b/rules/no-unknown-modifiers.js
@@ -44,7 +44,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/no-unknown-modifiers.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/prefer-async-await.js
+++ b/rules/prefer-async-await.js
@@ -49,5 +49,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/prefer-async-await.md'
+		}
+	}
 };

--- a/rules/prefer-async-await.js
+++ b/rules/prefer-async-await.js
@@ -1,6 +1,7 @@
 'use strict';
 const visitIf = require('enhance-visitors').visitIf;
 const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
 
 function containsThen(node) {
 	if (!node ||
@@ -51,7 +52,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/prefer-async-await.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -79,5 +79,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/prefer-power-assert.md'
+		}
+	}
 };

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -3,6 +3,7 @@ const espurify = require('espurify');
 const visitIf = require('enhance-visitors').visitIf;
 const deepStrictEqual = require('deep-strict-equal');
 const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
 
 const notAllowed = [
 	'truthy',
@@ -81,7 +82,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/prefer-power-assert.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/test-ended.js
+++ b/rules/test-ended.js
@@ -41,5 +41,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/test-ended.md'
+		}
+	}
 };

--- a/rules/test-ended.js
+++ b/rules/test-ended.js
@@ -1,6 +1,7 @@
 'use strict';
 const visitIf = require('enhance-visitors').visitIf;
 const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
 
 const create = context => {
 	const ava = createAvaRule();
@@ -43,7 +44,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/test-ended.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -42,6 +42,9 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/test-title.md'
+		},
 		schema
 	}
 };

--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -1,6 +1,7 @@
 'use strict';
 const visitIf = require('enhance-visitors').visitIf;
 const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
 
 const create = context => {
 	const ava = createAvaRule();
@@ -43,7 +44,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/test-title.md'
+			url: util.getDocsUrl()
 		},
 		schema
 	}

--- a/rules/use-t-well.js
+++ b/rules/use-t-well.js
@@ -106,7 +106,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/use-t-well.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/use-t-well.js
+++ b/rules/use-t-well.js
@@ -104,5 +104,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/use-t-well.md'
+		}
+	}
 };

--- a/rules/use-t.js
+++ b/rules/use-t.js
@@ -33,5 +33,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/use-t.md'
+		}
+	}
 };

--- a/rules/use-t.js
+++ b/rules/use-t.js
@@ -1,6 +1,7 @@
 'use strict';
 const visitIf = require('enhance-visitors').visitIf;
 const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
 
 const create = context => {
 	const ava = createAvaRule();
@@ -35,7 +36,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/use-t.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/use-test.js
+++ b/rules/use-test.js
@@ -38,5 +38,9 @@ const create = context => ({
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/use-test.md'
+		}
+	}
 };

--- a/rules/use-test.js
+++ b/rules/use-test.js
@@ -1,6 +1,7 @@
 'use strict';
 const espurify = require('espurify');
 const deepStrictEqual = require('deep-strict-equal');
+const util = require('../util');
 
 const avaVariableDeclaratorInitAst = {
 	type: 'CallExpression',
@@ -40,7 +41,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/use-test.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/use-true-false.js
+++ b/rules/use-true-false.js
@@ -88,7 +88,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/use-true-false.md'
+			url: util.getDocsUrl()
 		}
 	}
 };

--- a/rules/use-true-false.js
+++ b/rules/use-true-false.js
@@ -86,5 +86,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/avajs/eslint-plugin-ava/tree/master/docs/rules/use-true-false.md'
+		}
+	}
 };

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,17 @@
+import test from 'ava';
+import util from '../util';
+
+test('returns the URL of the a named rule\'s documentation', t => {
+	const url = 'https://github.com/avajs/eslint-plugin-ava/blob/master/docs/rules/foo.md';
+	t.is(util.getDocsUrl('foo'), url);
+});
+
+test('returns the URL of the a named rule\'s documentation at a commit hash', t => {
+	const url = 'https://github.com/avajs/eslint-plugin-ava/blob/bar/docs/rules/foo.md';
+	t.is(util.getDocsUrl('foo', 'bar'), url);
+});
+
+test('determines the rule name from the file', t => {
+	const url = 'https://github.com/avajs/eslint-plugin-ava/blob/master/docs/rules/util.md';
+	t.is(util.getDocsUrl(), url);
+});

--- a/util.js
+++ b/util.js
@@ -1,5 +1,6 @@
 'use strict';
 const fs = require('fs');
+const path = require('path');
 
 const functionExpressions = [
 	'FunctionExpression',
@@ -94,6 +95,20 @@ const getMembers = node => {
 };
 
 exports.getMembers = getMembers;
+
+const repoUrl = 'https://github.com/avajs/eslint-plugin-ava';
+/**
+ * Return the URL of the rule's documentation, either from parameter or the
+ * requiring file's name.
+ * @param  {String} ruleName The name of the rule to generate a URL for.
+ * @return {String}          The URL of the rule's documentation.
+ */
+const getDocsUrl = (ruleName, commitHash) => {
+	ruleName = ruleName || path.basename(module.parent.filename, '.js');
+	commitHash = commitHash || 'master';
+	return `${repoUrl}/blob/${commitHash}/docs/rules/${ruleName}.md`;
+};
+exports.getDocsUrl = getDocsUrl;
 
 const assertionMethodsNumArguments = new Map([
 	['deepEqual', 2],


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.