### PR TITLE
Do not use module.parent for resolving rule name

### DIFF
--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -150,7 +150,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		},
 		schema
 	}

--- a/rules/assertion-message.js
+++ b/rules/assertion-message.js
@@ -68,7 +68,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl('assertion-message', '4211212daf1bfcfff3ebc5d4efdc4ba1a87acbf1')
+			url: util.getDocsUrl(__filename, '4211212daf1bfcfff3ebc5d4efdc4ba1a87acbf1')
 		},
 		schema,
 		deprecated: true

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -62,7 +62,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		},
 		schema
 	}

--- a/rules/no-async-fn-without-await.js
+++ b/rules/no-async-fn-without-await.js
@@ -51,7 +51,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-cb-test.js
+++ b/rules/no-cb-test.js
@@ -25,7 +25,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-duplicate-modifiers.js
+++ b/rules/no-duplicate-modifiers.js
@@ -46,7 +46,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -63,7 +63,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -103,7 +103,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		},
 		schema
 	}

--- a/rules/no-invalid-end.js
+++ b/rules/no-invalid-end.js
@@ -27,7 +27,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-nested-tests.js
+++ b/rules/no-nested-tests.js
@@ -34,7 +34,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-only-test.js
+++ b/rules/no-only-test.js
@@ -33,7 +33,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/no-skip-assert.js
+++ b/rules/no-skip-assert.js
@@ -26,7 +26,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-skip-test.js
+++ b/rules/no-skip-test.js
@@ -33,7 +33,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/no-statement-after-end.js
+++ b/rules/no-statement-after-end.js
@@ -94,7 +94,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-todo-implementation.js
+++ b/rules/no-todo-implementation.js
@@ -25,7 +25,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-todo-test.js
+++ b/rules/no-todo-test.js
@@ -25,7 +25,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-unknown-modifiers.js
+++ b/rules/no-unknown-modifiers.js
@@ -44,7 +44,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/prefer-async-await.js
+++ b/rules/prefer-async-await.js
@@ -52,7 +52,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -82,7 +82,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/test-ended.js
+++ b/rules/test-ended.js
@@ -44,7 +44,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -44,7 +44,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		},
 		schema
 	}

--- a/rules/use-t-well.js
+++ b/rules/use-t-well.js
@@ -106,7 +106,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/use-t.js
+++ b/rules/use-t.js
@@ -36,7 +36,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/use-test.js
+++ b/rules/use-test.js
@@ -41,7 +41,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/use-true-false.js
+++ b/rules/use-true-false.js
@@ -88,7 +88,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: util.getDocsUrl()
+			url: util.getDocsUrl(__filename)
 		}
 	}
 };

--- a/test/util.js
+++ b/test/util.js
@@ -4,15 +4,15 @@ import pkg from '../package';
 
 test('returns the URL of the a named rule\'s documentation', t => {
 	const url = `https://github.com/avajs/eslint-plugin-ava/blob/v${pkg.version}/docs/rules/foo.md`;
-	t.is(util.getDocsUrl('foo'), url);
+	t.is(util.getDocsUrl('foo.js'), url);
 });
 
 test('returns the URL of the a named rule\'s documentation at a commit hash', t => {
 	const url = 'https://github.com/avajs/eslint-plugin-ava/blob/bar/docs/rules/foo.md';
-	t.is(util.getDocsUrl('foo', 'bar'), url);
+	t.is(util.getDocsUrl('foo.js', 'bar'), url);
 });
 
 test('determines the rule name from the file', t => {
 	const url = `https://github.com/avajs/eslint-plugin-ava/blob/v${pkg.version}/docs/rules/util.md`;
-	t.is(util.getDocsUrl(), url);
+	t.is(util.getDocsUrl(__filename), url);
 });

--- a/util.js
+++ b/util.js
@@ -104,8 +104,8 @@ const repoUrl = 'https://github.com/avajs/eslint-plugin-ava';
  * @param  {String} ruleName The name of the rule to generate a URL for.
  * @return {String}          The URL of the rule's documentation.
  */
-const getDocsUrl = (ruleName, commitHash) => {
-	ruleName = ruleName || path.basename(module.parent.filename, '.js');
+const getDocsUrl = (filename, commitHash) => {
+	const ruleName = path.basename(filename, '.js');
 	commitHash = commitHash || `v${pkg.version}`;
 	return `${repoUrl}/blob/${commitHash}/docs/rules/${ruleName}.md`;
 };


### PR DESCRIPTION
`module.parent` is cached after the first `require` and this results in nearly all rules having the URL to `assertion-arguments`. Here's a simple repro:

```js
'use strict';

const { rules } = require('eslint-plugin-ava');

const wrongLinks = [];

for (const ruleName of Object.keys(rules)) {
    const rule = rules[ruleName];
    const { url } = rule.meta.docs;
    if (!url.includes(ruleName)) wrongLinks.push(ruleName);
}

console.log(wrongLinks);
```

```
λ node rule-docs-url.js
[ 'max-asserts',
  'no-async-fn-without-await',
  'no-cb-test',
  'no-duplicate-modifiers',
  'no-identical-title',
  'no-ignored-test-files',
  'no-invalid-end',
  'no-nested-tests',
  'no-only-test',
  'no-skip-assert',
  'no-skip-test',
  'no-statement-after-end',
  'no-todo-implementation',
  'no-todo-test',
  'no-unknown-modifiers',
  'prefer-async-await',
  'prefer-power-assert',
  'test-ended',
  'test-title',
  'use-t-well',
  'use-t',
  'use-test',
  'use-true-false' ]
```

Credits to @SimenB for calling this out in https://github.com/jest-community/eslint-plugin-jest/commit/e0160e59e939e633282443f2fe5768ef09da2c48#r27576164.