### PR TITLE
Add support for the ava.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"arrify": "^1.0.1",
 		"deep-strict-equal": "^0.2.0",
 		"enhance-visitors": "^1.0.0",
+		"esm": "^3.0.41",
 		"espree": "^3.1.3",
 		"espurify": "^1.5.0",
 		"import-modules": "^1.1.0",

--- a/util.js
+++ b/util.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const pkg = require('./package');
+const esmRequire = require('esm')(module);
 
 const functionExpressions = [
 	'FunctionExpression',
@@ -33,7 +34,15 @@ exports.getAvaConfig = filepath => {
 
 	try {
 		const packageContent = JSON.parse(fs.readFileSync(filepath, 'utf8'));
-		return (packageContent && packageContent.ava) || defaultResult;
+
+		if (packageContent && packageContent.ava) {
+			return packageContent.ava;
+		}
+
+		const fileOptions = path.parse(filepath);
+		const avaConfig = esmRequire(path.join(fileOptions.dir, 'ava.config.js'));
+
+		return avaConfig.default;
 	} catch (err) {
 		return defaultResult;
 	}


### PR DESCRIPTION
Adds support for checking the `ava.config.js` when there is no `ava` config inside `package.json`.
This uses the `esm` module for parsing the config file.