### PR TITLE
Fix `use-t` failing on macros

### DIFF
--- a/rules/use-t.js
+++ b/rules/use-t.js
@@ -11,7 +11,12 @@ const create = context => {
 			ava.isInTestFile,
 			ava.isTestNode
 		])(node => {
-			const functionArg = node.arguments[node.arguments.length - 1];
+			const functionArgIndex = node.arguments.length - 1;
+			if (functionArgIndex > 1) {
+				return;
+			}
+
+			const functionArg = node.arguments[functionArgIndex];
 
 			if (!(functionArg && functionArg.params && functionArg.params.length > 0)) {
 				return;

--- a/test/use-t.js
+++ b/test/use-t.js
@@ -34,7 +34,10 @@ ruleTester.run('use-t', rule, {
 		header + 'test(testFunction);',
 		header + 'test.todo("test name");',
 		// Shouldn't be triggered since it's not a test file
-		'test(foo => {});'
+		'test(foo => {});',
+		header + 'test(macro, arg1, (p1) => {})',
+		header + 'test("name", macro, arg1, (p1) => {})',
+		header + 'test("name", macro, (p1) => {})'
 	],
 	invalid: [
 		{


### PR DESCRIPTION
As mentioned in #127, calls to test using macros would treat any function arguments to the macro as needing to meet the requirements of the use-t validation.

This change will evaluate functions for the "t" parameter only if the function is the first or second position of the call to test.

Fixes #127