### PR TITLE
Fix `no-import-test-files` rule incorrectly reporting module names ending in `.js`

### DIFF
--- a/rules/no-import-test-files.js
+++ b/rules/no-import-test-files.js
@@ -5,6 +5,11 @@ const pkgUp = require('pkg-up');
 const multimatch = require('multimatch');
 const util = require('../util');
 
+const externalModuleRegExp = /^\w/;
+function isExternalModule(name) {
+	return externalModuleRegExp.test(name);
+}
+
 function isTestFile(files, rootDir, sourceFile, importedFile) {
 	const absoluteImportedPath = path.resolve(path.dirname(sourceFile), importedFile);
 	const relativePath = path.relative(rootDir, absoluteImportedPath);
@@ -23,8 +28,12 @@ function getProjectInfo() {
 
 function createImportValidator(context, files, projectInfo, filename) {
 	return (node, importPath) => {
-		const isImportingTestFile = isTestFile(files, projectInfo.rootDir, filename, importPath);
+		const isImportingExternalModule = isExternalModule(importPath);
+		if (isImportingExternalModule) {
+			return;
+		}
 
+		const isImportingTestFile = isTestFile(files, projectInfo.rootDir, filename, importPath);
 		if (isImportingTestFile) {
 			context.report({
 				node,

--- a/test/no-import-test-files.js
+++ b/test/no-import-test-files.js
@@ -17,22 +17,22 @@ const rootDir = path.dirname(__dirname);
 const toPath = subPath => path.join(rootDir, subPath);
 
 util.getAvaConfig = () => ({
-	files: ['lib/*.test.js']
+	files: [
+		'lib/*.test.js',
+		'test/**/*.js'
+	]
 });
 
 ruleTester.run('no-import-test-files', rule, {
 	valid: [
+		'import test from \'ava\';',
+		'const test = require(\'ava\');',
+		'console.log()',
+		'const value = require(somePath);',
+		'var highlight = require(\'highlight.js\')',
 		{
-			code: 'import test from \'ava\';'
-		},
-		{
-			code: 'const test = require(\'ava\');'
-		},
-		{
-			code: 'console.log()'
-		},
-		{
-			code: 'const value = require(somePath);'
+			code: 'var highlight = require(\'highlight.js\')',
+			filename: toPath('test/index.js')
 		}
 	],
 	invalid: [
@@ -44,6 +44,11 @@ ruleTester.run('no-import-test-files', rule, {
 		{
 			code: 'import test from \'./foo.test.js\';',
 			filename: toPath('lib/foo.js'),
+			errors: [{message: 'Test files should not be imported'}]
+		},
+		{
+			code: 'import test from \'./bar.js\';',
+			filename: toPath('test/foo.js'),
 			errors: [{message: 'Test files should not be imported'}]
 		}
 	]


### PR DESCRIPTION
Fix #215 