### PR TITLE
Prevent incorrect detection of AVA functions when accessing through "context"

### DIFF
--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -94,8 +94,8 @@ const create = context => {
 			if (
 				callee.type !== 'MemberExpression' ||
 				!callee.property ||
-				util.nameOfRootObject(callee) !== 't' ||
-				util.isInContext(callee)
+				util.getNameOfRootNodeObject(callee) !== 't' ||
+				util.isPropertyUnderContext(callee)
 			) {
 				return;
 			}

--- a/rules/assertion-message.js
+++ b/rules/assertion-message.js
@@ -32,7 +32,7 @@ const create = context => {
 				return;
 			}
 
-			if (callee.property && util.nameOfRootObject(callee) === 't') {
+			if (callee.property && util.getNameOfRootNodeObject(callee) === 't') {
 				const nArgs = nbArguments(callee);
 
 				if (nArgs === -1) {

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -25,7 +25,7 @@ const create = context => {
 			if (
 				callee.property &&
 				!notAssertionMethods.includes(callee.property.name) &&
-				util.nameOfRootObject(callee) === 't'
+				util.getNameOfRootNodeObject(callee) === 't'
 			) {
 				const members = util.getMembers(callee).filter(name => name !== 'skip');
 

--- a/rules/no-invalid-end.js
+++ b/rules/no-invalid-end.js
@@ -13,8 +13,8 @@ const create = context => {
 		])(node => {
 			if (
 				node.property.name === 'end' &&
-				!ava.hasTestModifier('cb') &&
-				util.nameOfRootObject(node) === 't'
+				node.object.name === 't' &&
+				!ava.hasTestModifier('cb')
 			) {
 				context.report({
 					node,

--- a/rules/no-skip-assert.js
+++ b/rules/no-skip-assert.js
@@ -11,13 +11,14 @@ const create = context => {
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			if (node.property.name === 'skip' &&
-				util.getNameOfRootNodeObject(node) === 't' &&
-				!util.isPropertyUnderContext(node)) {
-				context.report({
-					node,
-					message: 'No assertions should be skipped.'
-				});
+			if (node.property.name === 'skip') {
+				const root = util.getRootNode(node);
+				if (root.object.name === 't' && util.assertionMethods.has(root.property.name)) {
+					context.report({
+						node,
+						message: 'No assertions should be skipped.'
+					});
+				}
 			}
 		})
 	});

--- a/rules/no-skip-assert.js
+++ b/rules/no-skip-assert.js
@@ -11,7 +11,7 @@ const create = context => {
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			if (node.property.name === 'skip' && util.nameOfRootObject(node) === 't') {
+			if (node.property.name === 'skip' && node.object.name === 't') {
 				context.report({
 					node,
 					message: 'No assertions should be skipped.'

--- a/rules/no-skip-assert.js
+++ b/rules/no-skip-assert.js
@@ -11,7 +11,9 @@ const create = context => {
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			if (node.property.name === 'skip' && node.object.name === 't') {
+			if (node.property.name === 'skip' &&
+				util.getNameOfRootNodeObject(node) === 't' &&
+				!util.isPropertyUnderContext(node)) {
 				context.report({
 					node,
 					message: 'No assertions should be skipped.'

--- a/rules/use-t-well.js
+++ b/rules/use-t-well.js
@@ -50,7 +50,7 @@ const create = context => {
 			ava.isInTestNode
 		])(node => {
 			if (node.parent.type === 'MemberExpression' ||
-					util.nameOfRootObject(node) !== 't') {
+					util.getNameOfRootNodeObject(node) !== 't') {
 				return;
 			}
 

--- a/rules/use-true-false.js
+++ b/rules/use-true-false.js
@@ -57,7 +57,7 @@ const create = context => {
 			if (
 				node.callee.type === 'MemberExpression' &&
 				(node.callee.property.name === 'truthy' || node.callee.property.name === 'falsy') &&
-				util.nameOfRootObject(node.callee) === 't'
+				node.callee.object.name === 't'
 			) {
 				const arg = node.arguments[0];
 

--- a/test/assertion-arguments.js
+++ b/test/assertion-arguments.js
@@ -53,6 +53,8 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, 't.true(true, \'message\');'),
 		testCase(false, 't.truthy(\'unicorn\', \'message\');'),
 		testCase(false, 't.snapshot(value, \'message\');'),
+		testCase(false, 't.context.plan();'),
+		testCase(false, 'foo.t.plan();'),
 		// Shouldn't be triggered since it's not a test file
 		testCase(false, 't.true(true);', false, false),
 

--- a/test/max-asserts.js
+++ b/test/max-asserts.js
@@ -34,6 +34,8 @@ ruleTester.run('max-asserts', rule, {
 			options: [2]
 		},
 		`${header} test(t => { t.context.bar(); ${nbAssertions(5)} });`,
+		`${header} test(t => { ${'t.context.is(1, 1); '.repeat(6)}});`,
+		`${header} test(t => { ${'foo.t.is(1, 1); '.repeat(6)}});`,
 		// Shouldn't be triggered since it's not a test file
 		`test(t => { ${nbAssertions(10)} });`
 	],

--- a/test/no-invalid-end.js
+++ b/test/no-invalid-end.js
@@ -20,6 +20,8 @@ ruleTester.run('no-invalid-end', rule, {
 		header + 'test.cb(t => { t.end.skip(); });',
 		header + 'test.cb.only(t => { t.end(); });',
 		header + 'notTest(t => { t.end(); });',
+		header + 'test(t => { t.context.end(); })',
+		header + 'test(t => { foo.t.end(); })',
 		// Shouldn't be triggered since it's not a test file
 		'test(t => { t.end(); });'
 	],

--- a/test/no-skip-assert.js
+++ b/test/no-skip-assert.js
@@ -15,27 +15,29 @@ ruleTester.run('no-skip-assert', rule, {
 	valid: [
 		header + 'test(t => { t.is(1, 1); });',
 		header + 'test.skip(t => { t.is(1, 1); });',
+		// Not an actual AVA skip
 		header + 'test(t => { notT.skip.is(1, 1); });',
-		header + 'test(t => { t.context.skip.is(1, 1); });',
-		header + 'test(t => { foo.t.skip.is(1, 1); });',
+		header + 'test(t => { t.context.is.skip(1, 1); });',
+		header + 'test(t => { foo.t.is.skip(1, 1); });',
+		header + 'test(t => { t.skip(); });',
 		// Shouldn't be triggered since it's not a test file
-		'test(t => { t.skip.is(1, 1); });'
+		'test(t => { t.is.skip(1, 1); });'
 	],
 	invalid: [
-		{
-			code: header + 'test(t => { t.skip.is(1, 1); });',
-			errors
-		},
 		{
 			code: header + 'test(t => { t.is.skip(1, 1); });',
 			errors
 		},
 		{
-			code: header + 'test.cb(t => { t.skip.is(1, 1); t.end(); });',
+			code: header + 'test(t => { t.true.skip(1); });',
 			errors
 		},
 		{
-			code: header + 'test.skip(t => { t.skip.is(1, 1); });',
+			code: header + 'test.cb(t => { t.is.skip(1, 1); t.end(); });',
+			errors
+		},
+		{
+			code: header + 'test.skip(t => { t.is.skip(1, 1); });',
 			errors
 		}
 	]

--- a/test/no-skip-assert.js
+++ b/test/no-skip-assert.js
@@ -27,6 +27,10 @@ ruleTester.run('no-skip-assert', rule, {
 			errors
 		},
 		{
+			code: header + 'test(t => { t.is.skip(1, 1); });',
+			errors
+		},
+		{
 			code: header + 'test.cb(t => { t.skip.is(1, 1); t.end(); });',
 			errors
 		},

--- a/test/no-skip-assert.js
+++ b/test/no-skip-assert.js
@@ -16,6 +16,8 @@ ruleTester.run('no-skip-assert', rule, {
 		header + 'test(t => { t.is(1, 1); });',
 		header + 'test.skip(t => { t.is(1, 1); });',
 		header + 'test(t => { notT.skip.is(1, 1); });',
+		header + 'test(t => { t.context.skip.is(1, 1); });',
+		header + 'test(t => { foo.t.skip.is(1, 1); });',
 		// Shouldn't be triggered since it's not a test file
 		'test(t => { t.skip.is(1, 1); });'
 	],

--- a/test/use-t-well.js
+++ b/test/use-t-well.js
@@ -58,6 +58,8 @@ ruleTester.run('use-t-well', rule, {
 		testCase('t.plan(1);'),
 		testCase('t.log(\'Unicorns\');'),
 		testCase('a.foo();'),
+		testCase('t.context.foo(a, a);'),
+		testCase('foo.t.bar(a, a);'),
 		// Shouldn't be triggered since it's not a test file
 		testCase('t.foo(a, a);', false),
 		testCase('t.foo;', false)

--- a/test/use-true-false.js
+++ b/test/use-true-false.js
@@ -53,6 +53,10 @@ ruleTester.run('use-true-false', rule, {
 		testCase('t.falsy(value + value)'),
 		testCase('t.truthy()'),
 		testCase('t.falsy()'),
+		testCase('t.context.truthy(true)'),
+		testCase('t.context.falsy(false)'),
+		testCase('foo.t.truthy(true)'),
+		testCase('foo.t.falsy(false)'),
 		// Shouldn't be triggered since it's not a test file
 		testCase('t.truthy(value === 1)', false)
 	],

--- a/util.js
+++ b/util.js
@@ -22,20 +22,20 @@ const defaultFiles = [
 	'**/*.test.js'
 ];
 
-exports.getRoot = node => {
+exports.getRootNode = node => {
 	if (node.object.type === 'MemberExpression') {
-		return exports.getRoot(node.object);
+		return exports.getRootNode(node.object);
 	}
 
 	return node;
 };
 
-exports.nameOfPropertyRootObject = node => {
-	return exports.getRoot(node).object.name;
+exports.getNameOfRootNodeObject = node => {
+	return exports.getRootNode(node).object.name;
 };
 
-exports.isInContext = node => {
-	return exports.getRoot(node).property.name === 'context';
+exports.isPropertyUnderContext = node => {
+	return exports.getRootNode(node).property.name === 'context';
 };
 
 const NO_SUCH_FILE = Symbol('no ava.config.js file');

--- a/util.js
+++ b/util.js
@@ -22,20 +22,20 @@ const defaultFiles = [
 	'**/*.test.js'
 ];
 
-exports.nameOfRootObject = node => {
+exports.getRoot = node => {
 	if (node.object.type === 'MemberExpression') {
-		return exports.nameOfRootObject(node.object);
+		return exports.getRoot(node.object);
 	}
 
-	return node.object.name;
+	return node;
+};
+
+exports.nameOfRootObject = node => {
+	return exports.getRoot(node).object.name;
 };
 
 exports.isInContext = node => {
-	if (node.object.type === 'MemberExpression') {
-		return exports.isInContext(node.object);
-	}
-
-	return node.property.name === 'context';
+	return exports.getRoot(node).property.name === 'context';
 };
 
 const NO_SUCH_FILE = Symbol('no ava.config.js file');

--- a/util.js
+++ b/util.js
@@ -30,7 +30,7 @@ exports.getRoot = node => {
 	return node;
 };
 
-exports.nameOfRootObject = node => {
+exports.nameOfPropertyRootObject = node => {
 	return exports.getRoot(node).object.name;
 };
 


### PR DESCRIPTION
Add tests for all rules using "nameOfRootObject"
Fix #223