### PR TITLE
Allow the use of `t.title` with the `use-t-well` rule

### DIFF
--- a/docs/rules/use-t-well.md
+++ b/docs/rules/use-t-well.md
@@ -30,6 +30,7 @@ import test from 'ava';
 test(t => {
 	t.deepEqual(value, [2]);
 	t.context.a = 100;
+	require('fixtures/' + t.title);
 	t.deepEqual.skip();
 });
 ```

--- a/docs/rules/use-t-well.md
+++ b/docs/rules/use-t-well.md
@@ -10,7 +10,7 @@ Prevent the use of unknown assertion methods and the access to members other tha
 ```js
 import test from 'ava';
 
-test(t => {
+test('main', t => {
 	t(value); // `t` is not a function
 	t.depEqual(value, [2]); // Unknown assertion method `depEqual`
 	t.contxt.foo = 100; // Unknown member `contxt`. Use `context.contxt` instead
@@ -27,10 +27,10 @@ test(t => {
 ```js
 import test from 'ava';
 
-test(t => {
+test('main', t => {
 	t.deepEqual(value, [2]);
 	t.context.a = 100;
-	require('fixtures/' + t.title);
+	require(`fixtures/${t.title}`);
 	t.deepEqual.skip();
 });
 ```

--- a/rules/use-t-well.js
+++ b/rules/use-t-well.js
@@ -70,6 +70,19 @@ const create = context => {
 				return;
 			}
 
+			if (members[0] === 'title') {
+				// Anything is fine when of the form `t.title...`
+				if (members.length === 1 && isCallExpression(node)) {
+					// Except `t.title()`
+					context.report({
+						node,
+						message: 'Unknown assertion method `title`.'
+					});
+				}
+
+				return;
+			}
+
 			if (isCallExpression(node)) {
 				if (stats.other.length > 0) {
 					context.report({

--- a/test/use-t-well.js
+++ b/test/use-t-well.js
@@ -53,6 +53,10 @@ ruleTester.run('use-t-well', rule, {
 		testCase('t.skip.deepEqual(a, a);'),
 		testCase('t.context.a = 1;'),
 		testCase('t.context.foo.skip();'),
+		testCase('console.log(t.context);'),
+		testCase('t.true(t.context.title(foo));'),
+		testCase('console.log(t.title);'),
+		testCase('t.true(t.title.includes(\'Unicorns\'));'),
 		testCase('setImmediate(t.end);'),
 		testCase('t.deepEqual;'),
 		testCase('t.plan(1);'),
@@ -86,6 +90,10 @@ ruleTester.run('use-t-well', rule, {
 		{
 			code: testCase('t.context();'),
 			errors: [error('Unknown assertion method `context`.')]
+		},
+		{
+			code: testCase('t.title();'),
+			errors: [error('Unknown assertion method `title`.')]
 		},
 		{
 			code: testCase('t.a = 1;'),


### PR DESCRIPTION
Fix #176 