### PR TITLE
Calling a `.cb` test with the first argument being a reference disables the rule

### DIFF
--- a/rules/test-ended.js
+++ b/rules/test-ended.js
@@ -5,28 +5,40 @@ const util = require('../util');
 
 const create = context => {
 	const ava = createAvaRule();
+	const hasCbModifier = () => ava.hasTestModifier('cb');
 	let endCalled = false;
 
 	return ava.merge({
 		MemberExpression: visitIf([
 			ava.isInTestFile,
-			ava.isInTestNode
+			ava.isInTestNode,
+			hasCbModifier
 		])(node => {
-			if (ava.hasTestModifier('cb') &&
-				node.object.name === 't' &&
+			if (node.object.name === 't' &&
 				node.property.name === 'end'
 			) {
 				endCalled = true;
 			}
 		}),
+		CallExpression: visitIf([
+			ava.isInTestFile,
+			ava.isTestNode,
+			hasCbModifier
+		])(node => {
+			const firstArg = node.arguments[0];
+			if (node.callee.property.name === 'cb' && firstArg.type === 'Identifier') {
+				const scope = context.getScope();
+				const exists = scope.references.some(ref => ref.identifier.name === firstArg.name);
+				if (exists) {
+					endCalled = true;
+				}
+			}
+		}),
 		'CallExpression:exit': visitIf([
 			ava.isInTestFile,
-			ava.isTestNode
+			ava.isTestNode,
+			hasCbModifier
 		])(node => {
-			if (!ava.hasTestModifier('cb')) {
-				return;
-			}
-
 			// Leaving test function
 			if (endCalled) {
 				endCalled = false;

--- a/test/test-ended.js
+++ b/test/test-ended.js
@@ -22,6 +22,8 @@ ruleTester.run('test-ended', rule, {
 		header + 'test.cb.only(t => { t.end(); });',
 		header + 'test.cb.skip.only(t => { t.end(); });',
 		header + 'test.only.cb.skip(t => { t.end(); });',
+		// Detecting that the called function has `end()` is not required #119
+		header + 'const macro = t => {};\ntest.cb(macro);',
 		// Shouldn't be triggered since it's not a callback test
 		header + 'test(t => { t.pass(); });',
 		// Shouldn't be triggered since it's not a test file
@@ -30,6 +32,11 @@ ruleTester.run('test-ended', rule, {
 	invalid: [
 		{
 			code: header + 'test.cb(function (t) { t.pass(); });',
+			errors
+		},
+		{
+			// Detecting that the called function has `end()` can turn into a recursive resolution nightmare
+			code: header + 'const macro = t => t.end();\ntest.cb((t) => macro(t));',
 			errors
 		},
 		{


### PR DESCRIPTION
Fix #119 