### PR TITLE
Secure function call without property on prefer-t-regex

### DIFF
--- a/rules/prefer-t-regex.js
+++ b/rules/prefer-t-regex.js
@@ -37,7 +37,7 @@ const create = context => {
 
 			// First argument is a call expression
 			const isFunctionCall = firstArg.type === 'CallExpression';
-			if (!isFunctionCall) {
+			if (!isFunctionCall || !firstArg.callee.property) {
 				return;
 			}
 

--- a/test/prefer-t-regex.js
+++ b/test/prefer-t-regex.js
@@ -23,6 +23,7 @@ ruleTester.run('prefer-t-regex', rule, {
 		header + 'test(t => t.true(foo.bar()));',
 		header + 'const a = /\\d+/;\ntest(t => t.truthy(a));',
 		header + 'const a = "not a regexp";\ntest(t => t.true(a.test("foo")));',
+		header + 'test("main", t => t.true(foo()));',
 		// Shouldn't be triggered since it's not a test file
 		'test(t => t.true(/\\d+/.test("foo")));'
 	],


### PR DESCRIPTION
Fix #251
