### PR TITLE
Ensure @scoped-packages are ignored in no-import-test-files

### DIFF
--- a/rules/no-import-test-files.js
+++ b/rules/no-import-test-files.js
@@ -2,10 +2,8 @@
 const path = require('path');
 const util = require('../util');
 
-const externalModuleRegExp = /^\w/;
-function isExternalModule(name) {
-	return externalModuleRegExp.test(name);
-}
+// Assume absolute paths can be classified by AVA.
+const isFileImport = name => path.isAbsolute(name) || name.startsWith('./') || name.startsWith('../');
 
 const create = context => {
 	const filename = context.getFilename();
@@ -24,8 +22,7 @@ const create = context => {
 			return;
 		}
 
-		const isImportingExternalModule = isExternalModule(importPath);
-		if (isImportingExternalModule) {
+		if (!isFileImport(importPath)) {
 			return;
 		}
 

--- a/test/no-import-test-files.js
+++ b/test/no-import-test-files.js
@@ -21,6 +21,10 @@ util.loadAvaHelper = () => ({
 		switch (importPath) {
 			case toPath('lib/foo.test.js'):
 				return {isHelper: false, isSource: false, isTest: true};
+			case toPath('../foo.test.js'):
+				return {isHelper: false, isSource: false, isTest: true};
+			case toPath('@foo/bar'): // Regression test for https://github.com/avajs/eslint-plugin-ava/issues/253
+				return {isHelper: false, isSource: false, isTest: true};
 			default:
 				return {isHelper: false, isSource: false, isTest: false};
 		}
@@ -36,6 +40,8 @@ const errors = [
 ruleTester.run('no-import-test-files', rule, {
 	valid: [
 		'import test from \'ava\';',
+		'import foo from \'@foo/bar\';',
+		'import foo from \'/foo/bar\';', // Classfied as not a test.
 		'const test = require(\'ava\');',
 		'console.log()',
 		'const value = require(somePath);',
@@ -51,6 +57,11 @@ ruleTester.run('no-import-test-files', rule, {
 		{
 			code: 'const test = require(\'./foo.test.js\');',
 			filename: toPath('lib/foo.js'),
+			errors
+		},
+		{
+			code: 'const test = require(\'../foo.test.js\');',
+			filename: toPath('foo.js'),
 			errors
 		}
 	]


### PR DESCRIPTION
Only attempt to classify imports that are file paths. Fixes #253.
