### PR TITLE
Support extensions, files and helpers in `no-ignored-test-files` and `no-import-test-files` rules

### DIFF
--- a/docs/rules/no-ignored-test-files.md
+++ b/docs/rules/no-ignored-test-files.md
@@ -36,3 +36,20 @@ test('foo', t => {
 	t.pass();
 });
 ```
+
+## Options
+
+This rule supports the following options:
+
+* `extensions`: an array of extensions of the files that AVA recognizes as test files or helpers. Overrides *both* the `babel.extensions` *and* `extensions` configuration otherwise used by AVA itself.
+* `files`: an array of glob patterns to select test files. Overrides the `files` configuration otherwise used by AVA itself.
+* `helpers`: an array of glob patterns to select helper files. Overrides the `helpers` configuration otherwise used by AVA itself.
+* `sources`: an array of glob patterns to match files that, when changed, cause tests to be re-run (when in watch mode). Overrides the `sources` configuration otherwise used by AVA itself.
+
+See also [AVA's configuration](https://github.com/avajs/ava/blob/master/docs/06-configuration.md#options).
+
+You can set the options like this:
+
+```js
+"ava/no-ignored-test-files": ["error", {"files": ["lib/**/*.test.js", "utils/**/*.test.js"]}]
+```

--- a/docs/rules/no-import-test-files.md
+++ b/docs/rules/no-import-test-files.md
@@ -36,3 +36,18 @@ import sinon from 'sinon';
 // File: src/index.js
 import utils from './utils';
 ```
+
+## Options
+
+This rule supports the following options:
+
+* `extensions`: an array of extensions of the files that AVA recognizes as test files or helpers. Overrides *both* the `babel.extensions` *and* `extensions` configuration otherwise used by AVA itself.
+* `files`: an array of glob patterns to select test files. Overrides the `files` configuration otherwise used by AVA itself.
+
+See also [AVA's configuration](https://github.com/avajs/ava/blob/master/docs/06-configuration.md#options).
+
+You can set the options like this:
+
+```js
+"ava/no-ignored-test-files": ["error", {"files": ["lib/**/*.test.js", "utils/**/*.test.js"]}]
+```

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -5,6 +5,7 @@ const createAvaRule = require('../create-ava-rule');
 
 const create = context => {
 	const filename = context.getFilename();
+	const [overrides] = context.options;
 
 	if (filename === '<text>') {
 		return {};
@@ -25,7 +26,7 @@ const create = context => {
 				return;
 			}
 
-			const avaHelper = util.loadAvaHelper(filename);
+			const avaHelper = util.loadAvaHelper(filename, overrides);
 			if (!avaHelper) {
 				return {};
 			}
@@ -47,12 +48,28 @@ const create = context => {
 	});
 };
 
+const schema = [{
+	type: 'object',
+	properties: {
+		extensions: {
+			type: 'array'
+		},
+		files: {
+			type: 'array'
+		},
+		helpers: {
+			type: 'array'
+		}
+	}
+}];
+
 module.exports = {
 	create,
 	meta: {
 		docs: {
 			url: util.getDocsUrl(__filename)
 		},
+		schema,
 		type: 'suggestion'
 	}
 };

--- a/rules/no-import-test-files.js
+++ b/rules/no-import-test-files.js
@@ -9,6 +9,7 @@ function isExternalModule(name) {
 
 const create = context => {
 	const filename = context.getFilename();
+	const [overrides] = context.options;
 
 	if (filename === '<text>') {
 		return {};
@@ -30,7 +31,7 @@ const create = context => {
 		}
 
 		if (!loadedAvaHelper) {
-			avaHelper = util.loadAvaHelper(filename);
+			avaHelper = util.loadAvaHelper(filename, overrides);
 			loadedAvaHelper = true;
 		}
 
@@ -63,12 +64,25 @@ const create = context => {
 	};
 };
 
+const schema = [{
+	type: 'object',
+	properties: {
+		extensions: {
+			type: 'array'
+		},
+		files: {
+			type: 'array'
+		}
+	}
+}];
+
 module.exports = {
 	create,
 	meta: {
 		docs: {
 			url: util.getDocsUrl(__filename)
 		},
+		schema,
 		type: 'suggestion'
 	}
 };

--- a/util.js
+++ b/util.js
@@ -4,7 +4,7 @@ const pkgDir = require('pkg-dir');
 const resolveFrom = require('resolve-from');
 const pkg = require('./package');
 
-exports.loadAvaHelper = filename => {
+exports.loadAvaHelper = (filename, overrides) => {
 	const rootDir = pkgDir.sync(filename);
 	if (!rootDir) {
 		return undefined;
@@ -16,7 +16,7 @@ exports.loadAvaHelper = filename => {
 	}
 
 	const avaHelper = require(avaHelperPath);
-	return avaHelper.load(rootDir);
+	return avaHelper.load(rootDir, overrides);
 };
 
 const functionExpressions = [


### PR DESCRIPTION
Fixes #252.

Depends on https://github.com/avajs/ava/pull/2150.