### PR TITLE
Add defaults to schema

### DIFF
--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -141,7 +141,8 @@ const schema = [{
 			enum: [
 				'always',
 				'never'
-			]
+			],
+			default: undefined
 		}
 	}
 }];

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -9,8 +9,7 @@ const notAssertionMethods = ['plan', 'end'];
 
 const create = context => {
 	const ava = createAvaRule();
-	// TODO: Remove default value once defaults can be applied to integers
-	// https://github.com/eslint/eslint/issues/11749
+	// TODO: Convert to options to an object so we can set default using JSON Schema (without using this fallback)
 	const maxAssertions = context.options[0] || MAX_ASSERTIONS_DEFAULT;
 	let assertionCount = 0;
 	let nodeToReport;

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -9,7 +9,8 @@ const notAssertionMethods = ['plan', 'end'];
 
 const create = context => {
 	const ava = createAvaRule();
-	// TODO: Convert to options to an object so we can set default using JSON Schema (without using this fallback)
+	// TODO: Convert options to object JSON Schema default works properly
+	// https://github.com/avajs/eslint-plugin-ava/issues/260
 	const maxAssertions = context.options[0] || MAX_ASSERTIONS_DEFAULT;
 	let assertionCount = 0;
 	let nodeToReport;

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -3,11 +3,15 @@ const {visitIf} = require('enhance-visitors');
 const util = require('../util');
 const createAvaRule = require('../create-ava-rule');
 
+const MAX_ASSERTIONS_DEFAULT = 5;
+
 const notAssertionMethods = ['plan', 'end'];
 
 const create = context => {
 	const ava = createAvaRule();
-	const maxAssertions = context.options[0] || 5;
+	// TODO: Remove default value once defaults can be applied to integers
+	// https://github.com/eslint/eslint/issues/11749
+	const maxAssertions = context.options[0] || MAX_ASSERTIONS_DEFAULT;
 	let assertionCount = 0;
 	let nodeToReport;
 
@@ -55,9 +59,12 @@ const create = context => {
 	});
 };
 
-const schema = [{
-	type: 'integer'
-}];
+const schema = [
+	{
+		type: 'integer',
+		default: MAX_ASSERTIONS_DEFAULT
+	}
+];
 
 module.exports = {
 	create,

--- a/rules/test-title-format.js
+++ b/rules/test-title-format.js
@@ -35,15 +35,17 @@ const create = context => {
 	});
 };
 
-const schema = [{
-	type: 'object',
-	properties: {
-		format: {
-			type: 'string',
-			default: undefined
+const schema = [
+	{
+		type: 'object',
+		properties: {
+			format: {
+				type: 'string',
+				default: undefined
+			}
 		}
 	}
-}];
+];
 
 module.exports = {
 	create,

--- a/rules/test-title-format.js
+++ b/rules/test-title-format.js
@@ -35,12 +35,23 @@ const create = context => {
 	});
 };
 
+const schema = [{
+	type: 'object',
+	properties: {
+		format: {
+			type: 'string',
+			default: undefined
+		}
+	}
+}];
+
 module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
 		docs: {
 			url: util.getDocsUrl(__filename)
-		}
+		},
+		schema
 	}
 };


### PR DESCRIPTION
Fixes #214.

Honestly, I'm not sure this issue makes a lot of sense. There were only three rules I saw that had options at all:

* `assertion-arguments`: Default is `undefined`. I added it explicitly but it seems kind of redundant.
* `max-asserts`: Cannot use a default as per https://github.com/avajs/eslint-plugin-ava/issues/214#issuecomment-478915717. I'm not a big fan of non-object options anyway. I recommend converting from the numeric option to an object which would then pick up the default. This would be a breaking change, though. Alternatively, set the default in `schema` but also use the fallback in `create`.
* `test-title-format`: Default is also `undefined`.

Am I missing something about this request? There was no `Object.assign` usage to replace.