### PR TITLE
Add `no-inline-assertions` rule

### DIFF
--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -2,6 +2,8 @@
 
 The test implementation should not purely consist of an inline assertion as assertions do not return a value and having them inline also makes the tests less readable.
 
+This rule is fixable. It will wrap assertions into brackets `{}`. The fixer would not insert extra space or linebreaks around brackets.  
+
 
 ## Fail
 

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -1,4 +1,4 @@
-# Ensure assertions are not called from an inline function
+# Ensure no assertions are called from inline functions
 
 Prevent assertions being called from an inline function, to make it clear that it does not return.
 
@@ -18,7 +18,7 @@ test('foo', t => { t.true(fn()) });
 ```js
 import test from 'ava';
 
-test('foo', t => 
+test('foo', t =>
 	t.true(fn())
 );
 ```

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -1,8 +1,8 @@
-# Ensure assertions are not called from an inline arrow function
+# Ensure assertions are not called from an inline function
 
 Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/related/eslint-plugin-ava/docs/rules/no-inline-assertions.md)
 
-Prevent assertions being called from an inline arrow function, to make it clear that it does not return.
+Prevent assertions being called from an inline function, to make it clear that it does not return.
 
 ## Fail
 ```js
@@ -20,7 +20,9 @@ test('foo', t => { t.true(fn()) });
 ```js
 import test from 'ava';
 
-test('foo', t => { t.log('Meow');t.true(fn()) });
+test('foo', t => 
+	t.true(fn())
+);
 ```
 
 ## Pass

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -2,7 +2,7 @@
 
 The test implementation should not purely consist of an inline assertion as assertions do not return a value and having them inline also makes the tests less readable.
 
-This rule is fixable. It will wrap assertions into brackets `{}`. The fixer would not insert extra space or linebreaks around brackets.  
+This rule is fixable. It will wrap the assertion in braces `{}`. It will not do any whitespace or style changes.
 
 
 ## Fail
@@ -20,6 +20,6 @@ test('foo', t => t.true(fn()));
 import test from 'ava';
 
 test('foo', t => {
-	t.true(fn())
+	t.true(fn());
 });
 ```

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -1,4 +1,4 @@
-# Ensure no assertions are called from inline functions
+# Ensure assertions are not called from inline arrow functions
 
 Prevent assertions being called from an inline function, to make it clear that it does not return.
 

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -1,7 +1,6 @@
 # Ensure assertions are not called from inline arrow functions
 
-Prevent assertions being called from an inline function, to make it clear that it does not return.
-
+An inline arrow function is an arrow function with concise body, i.e. `x => x` will return `x` to the caller. The test implementation, composed of a series of assertions, should not be an inline arrow function as assertions do not return.
 ## Fail
 ```js
 import test from 'ava';

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -1,0 +1,33 @@
+# Ensure assertions are not called from an inline arrow function
+
+Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/related/eslint-plugin-ava/docs/rules/no-inline-assertions.md)
+
+Prevent assertions being called from an inline arrow function, to make it clear that it does not return.
+
+## Fail
+```js
+import test from 'ava';
+
+test('foo', t => t.true(fn()));
+```
+
+```js
+import test from 'ava';
+
+test('foo', t => { t.true(fn()) });
+```
+
+```js
+import test from 'ava';
+
+test('foo', t => { t.log('Meow');t.true(fn()) });
+```
+
+## Pass
+```js
+import test from 'ava';
+
+test('foo', t => {
+	t.true(fn())
+});
+```

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -1,14 +1,19 @@
 # Ensure assertions are not called from inline arrow functions
 
-An inline arrow function is an arrow function with concise body, i.e. `x => x` will return `x` to the caller. The test implementation, composed of a series of assertions, should not be an inline arrow function as assertions do not return.
+The test implementation should not purely consist of an inline assertion as assertions do not return a value and having them inline also makes the tests less readable.
+
+
 ## Fail
+
 ```js
 import test from 'ava';
 
 test('foo', t => t.true(fn()));
 ```
 
+
 ## Pass
+
 ```js
 import test from 'ava';
 

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -9,20 +9,6 @@ import test from 'ava';
 test('foo', t => t.true(fn()));
 ```
 
-```js
-import test from 'ava';
-
-test('foo', t => { t.true(fn()) });
-```
-
-```js
-import test from 'ava';
-
-test('foo', t =>
-	t.true(fn())
-);
-```
-
 ## Pass
 ```js
 import test from 'ava';

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -1,7 +1,5 @@
 # Ensure assertions are not called from an inline function
 
-Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/related/eslint-plugin-ava/docs/rules/no-inline-assertions.md)
-
 Prevent assertions being called from an inline function, to make it clear that it does not return.
 
 ## Fail

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
 				'ava/no-identical-title': 'error',
 				'ava/no-ignored-test-files': 'error',
 				'ava/no-import-test-files': 'error',
+				'ava/no-inline-assertions': 'error',
 				'ava/no-invalid-end': 'error',
 				'ava/no-nested-tests': 'error',
 				'ava/no-only-test': 'error',

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ The rules will only activate in test files.
 - [no-identical-title](docs/rules/no-identical-title.md) - Ensure no tests have the same title.
 - [no-ignored-test-files](docs/rules/no-ignored-test-files.md) - Ensure no tests are written in ignored files.
 - [no-import-test-files](docs/rules/no-import-test-files.md) - Ensure no test files are imported anywhere.
-- [no-inline-assertions](docs/rules/no-inline-assertions.md) - Ensure assertions are not called from inline functions.
+- [no-inline-assertions](docs/rules/no-inline-assertions.md) - Ensure assertions are not called from inline arrow functions.
 - [no-invalid-end](docs/rules/no-invalid-end.md) - Ensure `t.end()` is only called inside `test.cb()`.
 - [no-nested-tests](docs/rules/no-nested-tests.md) - Ensure no tests are nested.
 - [no-only-test](docs/rules/no-only-test.md) - Ensure no `test.only()` are present. *(fixable)*

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ The rules will only activate in test files.
 - [no-identical-title](docs/rules/no-identical-title.md) - Ensure no tests have the same title.
 - [no-ignored-test-files](docs/rules/no-ignored-test-files.md) - Ensure no tests are written in ignored files.
 - [no-import-test-files](docs/rules/no-import-test-files.md) - Ensure no test files are imported anywhere.
-- [no-inline-assertions](docs/rules/no-inline-assertions.md) - Ensure assertions are not called from inline arrow functions.
+- [no-inline-assertions](docs/rules/no-inline-assertions.md) - Ensure assertions are not called from inline arrow functions. *(fixable)*
 - [no-invalid-end](docs/rules/no-invalid-end.md) - Ensure `t.end()` is only called inside `test.cb()`.
 - [no-nested-tests](docs/rules/no-nested-tests.md) - Ensure no tests are nested.
 - [no-only-test](docs/rules/no-only-test.md) - Ensure no `test.only()` are present. *(fixable)*

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ Configure it in `package.json`.
 			"ava/no-identical-title": "error",
 			"ava/no-ignored-test-files": "error",
 			"ava/no-import-test-files": "error",
+			"ava/no-inline-assertions": "error",
 			"ava/no-invalid-end": "error",
 			"ava/no-nested-tests": "error",
 			"ava/no-only-test": "error",
@@ -83,6 +84,7 @@ The rules will only activate in test files.
 - [no-identical-title](docs/rules/no-identical-title.md) - Ensure no tests have the same title.
 - [no-ignored-test-files](docs/rules/no-ignored-test-files.md) - Ensure no tests are written in ignored files.
 - [no-import-test-files](docs/rules/no-import-test-files.md) - Ensure no test files are imported anywhere.
+- [no-inline-assertions](docs/rules/no-inline-assertions.md) - Ensure no assertions are called from inline functions.
 - [no-invalid-end](docs/rules/no-invalid-end.md) - Ensure `t.end()` is only called inside `test.cb()`.
 - [no-nested-tests](docs/rules/no-nested-tests.md) - Ensure no tests are nested.
 - [no-only-test](docs/rules/no-only-test.md) - Ensure no `test.only()` are present. *(fixable)*

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ The rules will only activate in test files.
 - [no-identical-title](docs/rules/no-identical-title.md) - Ensure no tests have the same title.
 - [no-ignored-test-files](docs/rules/no-ignored-test-files.md) - Ensure no tests are written in ignored files.
 - [no-import-test-files](docs/rules/no-import-test-files.md) - Ensure no test files are imported anywhere.
-- [no-inline-assertions](docs/rules/no-inline-assertions.md) - Ensure no assertions are called from inline functions.
+- [no-inline-assertions](docs/rules/no-inline-assertions.md) - Ensure assertions are not called from inline functions.
 - [no-invalid-end](docs/rules/no-invalid-end.md) - Ensure `t.end()` is only called inside `test.cb()`.
 - [no-nested-tests](docs/rules/no-nested-tests.md) - Ensure no tests are nested.
 - [no-only-test](docs/rules/no-only-test.md) - Ensure no `test.only()` are present. *(fixable)*

--- a/rules/no-inline-assertions.js
+++ b/rules/no-inline-assertions.js
@@ -6,7 +6,7 @@ const util = require('../util');
 function report({node, context}) {
 	context.report({
 		node,
-		message: 'Assertions should not be called from an inline function'
+		message: 'Assertions should not be called from an inline function.'
 	});
 }
 

--- a/rules/no-inline-assertions.js
+++ b/rules/no-inline-assertions.js
@@ -6,7 +6,7 @@ const util = require('../util');
 function report({node, context}) {
 	context.report({
 		node,
-		message: 'Assertions should not be called from an inline function.'
+		message: 'The test implementation should not be an inline arrow function.'
 	});
 }
 
@@ -31,19 +31,6 @@ const create = context => {
 
 			const {body} = functionArg;
 			if (body.type === 'CallExpression') {
-				report({node, context});
-				return;
-			}
-
-			if (body.type === 'BlockStatement') {
-				if (body.loc.start.line !== body.loc.end.line) {
-					return;
-				}
-
-				if (body.body.length === 0) {
-					return;
-				}
-
 				report({node, context});
 			}
 		})

--- a/rules/no-inline-assertions.js
+++ b/rules/no-inline-assertions.js
@@ -3,13 +3,6 @@ const {visitIf} = require('enhance-visitors');
 const createAvaRule = require('../create-ava-rule');
 const util = require('../util');
 
-function report({node, context}) {
-	context.report({
-		node,
-		message: 'The test implementation should not be an inline arrow function.'
-	});
-}
-
 const create = context => {
 	const ava = createAvaRule();
 
@@ -31,7 +24,11 @@ const create = context => {
 
 			const {body} = functionArg;
 			if (body.type === 'CallExpression') {
-				report({node, context});
+				context.report({
+					node,
+					message: 'The test implementation should not be an inline arrow function.',
+					fix: fixer => [fixer.insertTextBefore(body, '{'), fixer.insertTextAfter(body, '}')]
+				});
 			}
 		})
 	});
@@ -43,6 +40,7 @@ module.exports = {
 		docs: {
 			url: util.getDocsUrl(__filename)
 		},
-		type: 'suggestion'
+		type: 'suggestion',
+		fixable: 'code'
 	}
 };

--- a/rules/no-inline-assertions.js
+++ b/rules/no-inline-assertions.js
@@ -3,12 +3,13 @@ const {visitIf} = require('enhance-visitors');
 const createAvaRule = require('../create-ava-rule');
 const util = require('../util');
 
-function report({ node, context }) {
+function report({node, context}) {
 	context.report({
-		node: node,
+		node,
 		message: 'Assertions should not be called from an inline function'
-	})
+	});
 }
+
 const create = context => {
 	const ava = createAvaRule();
 
@@ -28,24 +29,23 @@ const create = context => {
 				return;
 			}
 
-			const { body } = functionArg;
-			if (body.type === "CallExpression") {
-				report({ node, context });
+			const {body} = functionArg;
+			if (body.type === 'CallExpression') {
+				report({node, context});
 				return;
 			}
 
-			if (body.type === "BlockStatement") {
+			if (body.type === 'BlockStatement') {
 				if (body.loc.start.line !== body.loc.end.line) {
 					return;
 				}
 
-				if (!body.body.length) {
+				if (body.body.length === 0) {
 					return;
 				}
 
-				report({ node, context });
+				report({node, context});
 			}
-
 		})
 	});
 };

--- a/rules/no-inline-assertions.js
+++ b/rules/no-inline-assertions.js
@@ -1,0 +1,61 @@
+'use strict';
+const {visitIf} = require('enhance-visitors');
+const createAvaRule = require('../create-ava-rule');
+const util = require('../util');
+
+function report({ node, context }) {
+	context.report({
+		node: node,
+		message: 'Assertions should not be called from an inline function'
+	})
+}
+const create = context => {
+	const ava = createAvaRule();
+
+	return ava.merge({
+		CallExpression: visitIf([
+			ava.isInTestFile,
+			ava.isTestNode
+		])(node => {
+			const functionArgIndex = node.arguments.length - 1;
+			if (functionArgIndex > 1) {
+				return;
+			}
+
+			const functionArg = node.arguments[functionArgIndex];
+
+			if (!util.isFunctionExpression(functionArg)) {
+				return;
+			}
+
+			const { body } = functionArg;
+			if (body.type === "CallExpression") {
+				report({ node, context });
+				return;
+			}
+
+			if (body.type === "BlockStatement") {
+				if (body.loc.start.line !== body.loc.end.line) {
+					return;
+				}
+
+				if (!body.body.length) {
+					return;
+				}
+
+				report({ node, context });
+			}
+
+		})
+	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {
+			url: util.getDocsUrl(__filename)
+		},
+		type: 'suggestion'
+	}
+};

--- a/test/no-inline-assertions.js
+++ b/test/no-inline-assertions.js
@@ -15,12 +15,12 @@ ruleTester.run('no-todo-test', rule, {
 	valid: [
 		// Shouldn't be treiggered as the test implementation is not an inline arrow function
 		header + 'test("my test name", t => {\n t.true(fn()); \n});',
-		header + 'test("my test name", function(t) { foo(); });',
+		header + 'test("my test name", function (t) { foo(); });',
 		// Shouldn't be triggered since test body is empty
 		header + 'test("my test name", () => {});',
-		header + 'test("my test name", (t) => {});',
+		header + 'test("my test name", t => {});',
 		// Shouldn't be triggered since test body is ill-defined
-		header + 'test("my test name", (t) => "foo");',
+		header + 'test("my test name", t => "foo");',
 		// Shouldn't be triggered since it's not a test file
 		'test.todo("my test name");',
 		// Shouldn't be triggered since the signature is incorrect

--- a/test/no-inline-assertions.js
+++ b/test/no-inline-assertions.js
@@ -13,7 +13,9 @@ const header = 'const test = require(\'ava\');\n';
 
 ruleTester.run('no-todo-test', rule, {
 	valid: [
+		// Shouldn't be treiggered as the test implementation is not an inline arrow function
 		header + 'test("my test name", t => {\n t.true(fn()); \n});',
+		header + 'test("my test name", function(t) { foo(); });',
 		// Shouldn't be triggered since test body is empty
 		header + 'test("my test name", () => {});',
 		header + 'test("my test name", (t) => {});',
@@ -27,10 +29,6 @@ ruleTester.run('no-todo-test', rule, {
 	],
 	invalid: [
 		{
-			code: header + 'test("my test name", t => { t.skip(); });',
-			errors
-		},
-		{
 			code: header + 'test("my test name", t => t.skip());',
 			errors
 		},
@@ -40,18 +38,6 @@ ruleTester.run('no-todo-test', rule, {
 		},
 		{
 			code: header + 'test("my test name", t => \n t.true(fn()));',
-			errors
-		},
-		{
-			code: header + 'test("my test name", t => { t.true(fn()) });',
-			errors
-		},
-		{
-			code: header + 'test("my test name", function(t) { foo(); });',
-			errors
-		},
-		{
-			code: header + 'test("my test name", t => { return t.true(fn()) });',
 			errors
 		}
 	]

--- a/test/no-inline-assertions.js
+++ b/test/no-inline-assertions.js
@@ -13,7 +13,7 @@ const header = 'const test = require(\'ava\');\n';
 
 ruleTester.run('no-todo-test', rule, {
 	valid: [
-		// Shouldn't be treiggered as the test implementation is not an inline arrow function
+		// Shouldn't be triggered as the test implementation is not an inline arrow function
 		header + 'test("my test name", t => {\n t.true(fn()); \n});',
 		header + 'test("my test name", function (t) { foo(); });',
 		// Shouldn't be triggered since test body is empty

--- a/test/no-inline-assertions.js
+++ b/test/no-inline-assertions.js
@@ -30,15 +30,18 @@ ruleTester.run('no-todo-test', rule, {
 	invalid: [
 		{
 			code: header + 'test("my test name", t => t.skip());',
-			errors
+			errors,
+			output: header + 'test("my test name", t => {t.skip()});'
 		},
 		{
 			code: header + 'test("my test name", t => t.true(fn()));',
-			errors
+			errors,
+			output: header + 'test("my test name", t => {t.true(fn())});'
 		},
 		{
 			code: header + 'test("my test name", t => \n t.true(fn()));',
-			errors
+			errors,
+			output: header + 'test("my test name", t => \n {t.true(fn())});'
 		}
 	]
 });

--- a/test/no-inline-assertions.js
+++ b/test/no-inline-assertions.js
@@ -1,0 +1,58 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-inline-assertions';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+const errors = [{ruleId: 'no-inline-assertions'}];
+const header = 'const test = require(\'ava\');\n';
+
+ruleTester.run('no-todo-test', rule, {
+	valid: [
+		header + 'test("my test name", t => {\n t.true(fn()); \n});',
+		// Shouldn't be triggered since test body is empty
+		header + 'test("my test name", () => {});',
+		header + 'test("my test name", (t) => {});',
+		// Shouldn't be triggered since test body is ill-defined
+		header + 'test("my test name", (t) => "foo");',
+		// Shouldn't be triggered since it's not a test file
+		'test.todo("my test name");',
+		// Shouldn't be triggered since the signature is incorrect
+		header + 'test.todo("my test name", "bar");',
+		header + 'test.todo("my test name", undefined, t => {})'
+	],
+	invalid: [
+		{
+			code: header + 'test("my test name", t => { t.skip(); });',
+			errors
+		},
+		{
+			code: header + 'test("my test name", t => t.skip());',
+			errors
+		},
+		{
+			code: header + 'test("my test name", t => t.true(fn()));',
+			errors
+		},
+		{
+			code: header + 'test("my test name", t => \n t.true(fn()));',
+			errors
+		},
+		{
+			code: header + 'test("my test name", t => { t.true(fn()) });',
+			errors
+		},
+		{
+			code: header + 'test("my test name", function(t) { foo(); });',
+			errors
+		},
+		{
+			code: header + 'test("my test name", t => { return t.true(fn()) });',
+			errors
+		}
+	]
+});


### PR DESCRIPTION
Update (2019-06-13): I have pushed `no-inline-assertions` rule implementation, see the docs and test cases. This rule will fail

Any `MemberExpression` as the arrow function body
```js
test('foo', t => t.true(fn()));
test('foo', t => t.skip());
test('foo', t => 
    t.true(fn())
);
// ...
```

And any `BlockStatement` within the same line
```js
test('foo', t => { t.true(fn()) });
test('foo', t => { t.skip() });
```

---
(2019-06-12)
This is an early-stage design discussion, as I have the following question regards to this rule. I would also put up my thoughts and any community input is welcome.

## Background: Recap of #152
The `no-inline-assertions` was originally proposed at #152, where Sindre listed two example

### Pass
```js
test('foo', t => t.true(fn()));
```

### Failure
```js
test('foo', t => {
    t.true(fn());
});
```

## Question on extra examples
While the example above is unambiguous, there is more question to be addressed after I ponder for a while.

1. Should inline arrow function with block statement be failed?
```js
test('foo', t => { t.true(fn()) });
```

2. Should inline arrow function with a return statement be failed?
```js
test('foo', t => { return t.true(fn()) });
```

3. Should inline arrow function with assertion call as last expression be failed?

```js
test('foo', t => { t.log('Meow');t.true(fn()) });
```

Here are my thoughts on these cases,
On the first, I think it should be failed as an inline arrow function with block statement is still *inline*.
On the second one, I think there should be a separate rule, e.g. `no-return-assertions` to take care of this. Otherwise we will have also to fail the following case
```js
test('foo', t => {
  return t.true(fn());
});
```
which is, of course, not an *inline* arrow function. So rule `no-inline-assertions` should not be triggered by case 2.

On the third one, I think it should be failed as it is still an *inline* arrow function with assertion calls inside. But I am not an ava user so I can't triage the impact of the third case. Is it common? Or we can neglect this case?

The docs here reflects my thoughts and is suggested to any changes.

Fixes #152