### PR TITLE
Add `no-incorrect-deep-equal` rule

### DIFF
--- a/docs/rules/no-incorrect-deep-equal.md
+++ b/docs/rules/no-incorrect-deep-equal.md
@@ -1,6 +1,6 @@
-# Avoid using `deepEqual` with literals
+# Avoid using `deepEqual` with primitives
 
-`deepEqual` and `notDeepEqual` are unnecessary when comparing literals, template strings or `undefined`. Use `is` or `not` instead.
+The `deepEqual` and `notDeepEqual` assertions are unnecessary when comparing primitives. Use `is` or `not` instead.
 
 This rule is fixable.
 

--- a/docs/rules/no-incorrect-deep-equal.md
+++ b/docs/rules/no-incorrect-deep-equal.md
@@ -1,0 +1,28 @@
+# Avoid using `deepEqual` with literals
+
+`deepEqual` and `notDeepEqual` are unnecessary when comparing literals, template strings or `undefined`. Use `is` or `not` instead.
+
+This rule is fixable.
+
+## Fail
+
+```js
+t.deepEqual(expression, 'foo');
+t.deepEqual(expression, 1);
+t.deepEqual(expression, `foo${bar}`);
+t.deepEqual(expression, null);
+t.deepEqual(expression, undefined);
+t.notDeepEqual(expression, undefined);
+```
+
+
+## Pass
+
+```js
+t.is(expression, 'foo');
+
+t.deepEqual(expression, otherExpression);
+t.deepEqual(expression, {});
+t.deepEqual(expression, []);
+t.notDeepEqual(expression, []);
+```

--- a/docs/rules/no-incorrect-deep-equal.md
+++ b/docs/rules/no-incorrect-deep-equal.md
@@ -4,6 +4,7 @@ The `deepEqual` and `notDeepEqual` assertions are unnecessary when comparing pri
 
 This rule is fixable.
 
+
 ## Fail
 
 ```js

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
 				'ava/no-identical-title': 'error',
 				'ava/no-ignored-test-files': 'error',
 				'ava/no-import-test-files': 'error',
+				'ava/no-incorrect-deep-equal': 'error',
 				'ava/no-invalid-end': 'error',
 				'ava/no-nested-tests': 'error',
 				'ava/no-only-test': 'error',

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ Configure it in `package.json`.
 			"ava/no-identical-title": "error",
 			"ava/no-ignored-test-files": "error",
 			"ava/no-import-test-files": "error",
+			"ava/no-incorrect-deep-equal": "error",
 			"ava/no-invalid-end": "error",
 			"ava/no-nested-tests": "error",
 			"ava/no-only-test": "error",
@@ -83,6 +84,7 @@ The rules will only activate in test files.
 - [no-identical-title](docs/rules/no-identical-title.md) - Ensure no tests have the same title.
 - [no-ignored-test-files](docs/rules/no-ignored-test-files.md) - Ensure no tests are written in ignored files.
 - [no-import-test-files](docs/rules/no-import-test-files.md) - Ensure no test files are imported anywhere.
+- [no-incorrect-deep-equal](docs/rules/no-incorrect-deep-equal.md) - Avoid using `deepEqual` with literals. *(fixable)*
 - [no-invalid-end](docs/rules/no-invalid-end.md) - Ensure `t.end()` is only called inside `test.cb()`.
 - [no-nested-tests](docs/rules/no-nested-tests.md) - Ensure no tests are nested.
 - [no-only-test](docs/rules/no-only-test.md) - Ensure no `test.only()` are present. *(fixable)*

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ The rules will only activate in test files.
 - [no-identical-title](docs/rules/no-identical-title.md) - Ensure no tests have the same title.
 - [no-ignored-test-files](docs/rules/no-ignored-test-files.md) - Ensure no tests are written in ignored files.
 - [no-import-test-files](docs/rules/no-import-test-files.md) - Ensure no test files are imported anywhere.
-- [no-incorrect-deep-equal](docs/rules/no-incorrect-deep-equal.md) - Avoid using `deepEqual` with literals. *(fixable)*
+- [no-incorrect-deep-equal](docs/rules/no-incorrect-deep-equal.md) - Avoid using `deepEqual` with primitives. *(fixable)*
 - [no-invalid-end](docs/rules/no-invalid-end.md) - Ensure `t.end()` is only called inside `test.cb()`.
 - [no-nested-tests](docs/rules/no-nested-tests.md) - Ensure no tests are nested.
 - [no-only-test](docs/rules/no-only-test.md) - Ensure no `test.only()` are present. *(fixable)*

--- a/rules/no-incorrect-deep-equal.js
+++ b/rules/no-incorrect-deep-equal.js
@@ -1,0 +1,117 @@
+'use strict';
+const {visitIf} = require('enhance-visitors');
+const util = require('../util');
+const createAvaRule = require('../create-ava-rule');
+
+const MESSAGE_ID_LITERAL = 'no-deep-equal-with-literal';
+const MESSAGE_ID_TEMPLATE = 'no-deep-equal-with-template';
+const MESSAGE_ID_UNDEFINED = 'no-deep-equal-with-undefined';
+
+const fixIs = (fixer, node) => {
+	return fixer.replaceText(node.callee.property, 'is');
+};
+
+const fixNot = (fixer, node) => {
+	return fixer.replaceText(node.callee.property, 'not');
+};
+
+const create = context => {
+	const ava = createAvaRule();
+
+	return ava.merge({
+		'CallExpression[callee.property.name="deepEqual"][arguments.1.type="Literal"]': visitIf([
+			ava.isInTestFile,
+			ava.isInTestNode
+		])(node => {
+			context.report({
+				node,
+				messageId: MESSAGE_ID_LITERAL,
+				data: {
+					callee: node.callee.property.name
+				},
+				fix: fixer => fixIs(fixer, node)
+			});
+		}),
+		'CallExpression[callee.property.name="deepEqual"][arguments.1.type="Identifier"][arguments.1.name="undefined"]': visitIf([
+			ava.isInTestFile,
+			ava.isInTestNode
+		])(node => {
+			context.report({
+				node,
+				messageId: MESSAGE_ID_UNDEFINED,
+				data: {
+					callee: node.callee.property.name
+				},
+				fix: fixer => fixIs(fixer, node)
+			});
+		}),
+		'CallExpression[callee.property.name="deepEqual"][arguments.1.type="TemplateLiteral"]': visitIf([
+			ava.isInTestFile,
+			ava.isInTestNode
+		])(node => {
+			context.report({
+				node,
+				messageId: MESSAGE_ID_TEMPLATE,
+				data: {
+					callee: node.callee.property.name
+				},
+				fix: fixer => fixIs(fixer, node)
+			});
+		}),
+		'CallExpression[callee.property.name="notDeepEqual"][arguments.1.type="Literal"]': visitIf([
+			ava.isInTestFile,
+			ava.isInTestNode
+		])(node => {
+			context.report({
+				node,
+				messageId: MESSAGE_ID_LITERAL,
+				data: {
+					callee: node.callee.property.name
+				},
+				fix: fixer => fixNot(fixer, node)
+			});
+		}),
+		'CallExpression[callee.property.name="notDeepEqual"][arguments.1.type="Identifier"][arguments.1.name="undefined"]': visitIf([
+			ava.isInTestFile,
+			ava.isInTestNode
+		])(node => {
+			context.report({
+				node,
+				messageId: MESSAGE_ID_UNDEFINED,
+				data: {
+					callee: node.callee.property.name
+				},
+				fix: fixer => fixNot(fixer, node)
+			});
+		}),
+		'CallExpression[callee.property.name="notDeepEqual"][arguments.1.type="TemplateLiteral"]': visitIf([
+			ava.isInTestFile,
+			ava.isInTestNode
+		])(node => {
+			context.report({
+				node,
+				messageId: MESSAGE_ID_TEMPLATE,
+				data: {
+					callee: node.callee.property.name
+				},
+				fix: fixer => fixNot(fixer, node)
+			});
+		})
+	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {
+			url: util.getDocsUrl(__filename)
+		},
+		fixable: true,
+		messages: {
+			[MESSAGE_ID_LITERAL]: 'Avoid using `{{callee}}` with literals',
+			[MESSAGE_ID_TEMPLATE]: 'Avoid using `{{callee}}` with templates',
+			[MESSAGE_ID_UNDEFINED]: 'Avoid using `{{callee}}` with `undefined`'
+		},
+		type: 'suggestion'
+	}
+};

--- a/rules/no-incorrect-deep-equal.js
+++ b/rules/no-incorrect-deep-equal.js
@@ -18,8 +18,16 @@ const fixNot = (fixer, node) => {
 const create = context => {
 	const ava = createAvaRule();
 
+	const callExpression = 'CallExpression';
+	const deepEqual = '[callee.property.name="deepEqual"]';
+	const notDeepEqual = '[callee.property.name="notDeepEqual"]';
+
+	const argumentsLiteral = ':matches([arguments.0.type="Literal"],[arguments.1.type="Literal"])';
+	const argumentsUndefined = ':matches([arguments.0.type="Identifier"][arguments.0.name="undefined"],[arguments.1.type="Identifier"][arguments.1.name="undefined"])';
+	const argumentsTemplate = ':matches([arguments.0.type="TemplateLiteral"],[arguments.1.type="TemplateLiteral"])';
+
 	return ava.merge({
-		'CallExpression[callee.property.name="deepEqual"][arguments.1.type="Literal"]': visitIf([
+		[`${callExpression}${deepEqual}${argumentsLiteral}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
@@ -32,7 +40,7 @@ const create = context => {
 				fix: fixer => fixIs(fixer, node)
 			});
 		}),
-		'CallExpression[callee.property.name="deepEqual"][arguments.1.type="Identifier"][arguments.1.name="undefined"]': visitIf([
+		[`${callExpression}${deepEqual}${argumentsUndefined}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
@@ -45,7 +53,7 @@ const create = context => {
 				fix: fixer => fixIs(fixer, node)
 			});
 		}),
-		'CallExpression[callee.property.name="deepEqual"][arguments.1.type="TemplateLiteral"]': visitIf([
+		[`${callExpression}${deepEqual}${argumentsTemplate}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
@@ -58,7 +66,7 @@ const create = context => {
 				fix: fixer => fixIs(fixer, node)
 			});
 		}),
-		'CallExpression[callee.property.name="notDeepEqual"][arguments.1.type="Literal"]': visitIf([
+		[`${callExpression}${notDeepEqual}${argumentsLiteral}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
@@ -71,7 +79,7 @@ const create = context => {
 				fix: fixer => fixNot(fixer, node)
 			});
 		}),
-		'CallExpression[callee.property.name="notDeepEqual"][arguments.1.type="Identifier"][arguments.1.name="undefined"]': visitIf([
+		[`${callExpression}${notDeepEqual}${argumentsUndefined}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
@@ -84,7 +92,7 @@ const create = context => {
 				fix: fixer => fixNot(fixer, node)
 			});
 		}),
-		'CallExpression[callee.property.name="notDeepEqual"][arguments.1.type="TemplateLiteral"]': visitIf([
+		[`${callExpression}${notDeepEqual}${argumentsTemplate}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {

--- a/rules/no-incorrect-deep-equal.js
+++ b/rules/no-incorrect-deep-equal.js
@@ -3,16 +3,28 @@ const {visitIf} = require('enhance-visitors');
 const util = require('../util');
 const createAvaRule = require('../create-ava-rule');
 
-const MESSAGE_ID_LITERAL = 'no-deep-equal-with-literal';
-const MESSAGE_ID_TEMPLATE = 'no-deep-equal-with-template';
-const MESSAGE_ID_UNDEFINED = 'no-deep-equal-with-undefined';
+const MESSAGE_ID = 'no-deep-equal-with-primative';
 
-const fixIs = (fixer, node) => {
-	return fixer.replaceText(node.callee.property, 'is');
+const buildDeepEqualMessage = (context, node) => {
+	context.report({
+		node,
+		messageId: MESSAGE_ID,
+		data: {
+			callee: node.callee.property.name
+		},
+		fix: fixer => fixer.replaceText(node.callee.property, 'is')
+	});
 };
 
-const fixNot = (fixer, node) => {
-	return fixer.replaceText(node.callee.property, 'not');
+const buildNotDeepEqualMessage = (context, node) => {
+	context.report({
+		node,
+		messageId: MESSAGE_ID,
+		data: {
+			callee: node.callee.property.name
+		},
+		fix: fixer => fixer.replaceText(node.callee.property, 'not')
+	});
 };
 
 const create = context => {
@@ -31,79 +43,37 @@ const create = context => {
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			context.report({
-				node,
-				messageId: MESSAGE_ID_LITERAL,
-				data: {
-					callee: node.callee.property.name
-				},
-				fix: fixer => fixIs(fixer, node)
-			});
+			buildDeepEqualMessage(context, node);
 		}),
 		[`${callExpression}${deepEqual}${argumentsUndefined}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			context.report({
-				node,
-				messageId: MESSAGE_ID_UNDEFINED,
-				data: {
-					callee: node.callee.property.name
-				},
-				fix: fixer => fixIs(fixer, node)
-			});
+			buildDeepEqualMessage(context, node);
 		}),
 		[`${callExpression}${deepEqual}${argumentsTemplate}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			context.report({
-				node,
-				messageId: MESSAGE_ID_TEMPLATE,
-				data: {
-					callee: node.callee.property.name
-				},
-				fix: fixer => fixIs(fixer, node)
-			});
+			buildDeepEqualMessage(context, node);
 		}),
 		[`${callExpression}${notDeepEqual}${argumentsLiteral}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			context.report({
-				node,
-				messageId: MESSAGE_ID_LITERAL,
-				data: {
-					callee: node.callee.property.name
-				},
-				fix: fixer => fixNot(fixer, node)
-			});
+			buildNotDeepEqualMessage(context, node);
 		}),
 		[`${callExpression}${notDeepEqual}${argumentsUndefined}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			context.report({
-				node,
-				messageId: MESSAGE_ID_UNDEFINED,
-				data: {
-					callee: node.callee.property.name
-				},
-				fix: fixer => fixNot(fixer, node)
-			});
+			buildNotDeepEqualMessage(context, node);
 		}),
 		[`${callExpression}${notDeepEqual}${argumentsTemplate}`]: visitIf([
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			context.report({
-				node,
-				messageId: MESSAGE_ID_TEMPLATE,
-				data: {
-					callee: node.callee.property.name
-				},
-				fix: fixer => fixNot(fixer, node)
-			});
+			buildNotDeepEqualMessage(context, node);
 		})
 	});
 };
@@ -116,9 +86,7 @@ module.exports = {
 		},
 		fixable: true,
 		messages: {
-			[MESSAGE_ID_LITERAL]: 'Avoid using `{{callee}}` with literals',
-			[MESSAGE_ID_TEMPLATE]: 'Avoid using `{{callee}}` with templates',
-			[MESSAGE_ID_UNDEFINED]: 'Avoid using `{{callee}}` with `undefined`'
+			[MESSAGE_ID]: 'Avoid using `{{callee}}` with literal primitives',
 		},
 		type: 'suggestion'
 	}

--- a/rules/no-incorrect-deep-equal.js
+++ b/rules/no-incorrect-deep-equal.js
@@ -86,7 +86,7 @@ module.exports = {
 		},
 		fixable: true,
 		messages: {
-			[MESSAGE_ID]: 'Avoid using `{{callee}}` with literal primitives',
+			[MESSAGE_ID]: 'Avoid using `{{callee}}` with literal primitives'
 		},
 		type: 'suggestion'
 	}

--- a/test/no-incorrect-deep-equal.js
+++ b/test/no-incorrect-deep-equal.js
@@ -8,19 +8,9 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
-const errorLiteral = {
+const error = {
 	ruleId: 'no-incorrect-deep-equal',
-	messageId: 'no-deep-equal-with-literal'
-};
-
-const errorTemplate = {
-	ruleId: 'no-incorrect-deep-equal',
-	messageId: 'no-deep-equal-with-template'
-};
-
-const errorUndefined = {
-	ruleId: 'no-incorrect-deep-equal',
-	messageId: 'no-deep-equal-with-undefined'
+	messageId: 'no-deep-equal-with-primative'
 };
 
 const header = 'const test = require(\'ava\');\n';
@@ -66,7 +56,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.is(expression, 'foo');
 				});
 			`,
-			errors: [errorLiteral]
+			errors: [error]
 		},
 		{
 			code: `
@@ -81,7 +71,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.is('foo', expression);
 				});
 			`,
-			errors: [errorLiteral]
+			errors: [error]
 		},
 		{
 			code: `
@@ -96,7 +86,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.not(expression, 'foo');
 				});
 			`,
-			errors: [errorLiteral]
+			errors: [error]
 		},
 		{
 			code: `
@@ -111,7 +101,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.not('foo', expression);
 				});
 			`,
-			errors: [errorLiteral]
+			errors: [error]
 		},
 		{
 			code: `
@@ -126,7 +116,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.is(expression, 1);
 				});
 			`,
-			errors: [errorLiteral]
+			errors: [error]
 		},
 		{
 			code: `
@@ -141,7 +131,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.is(expression, \`foo\${bar}\`);
 				});
 			`,
-			errors: [errorTemplate]
+			errors: [error]
 		},
 		{
 			code: `
@@ -156,7 +146,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.is(\`foo\${bar}\`, expression);
 				});
 			`,
-			errors: [errorTemplate]
+			errors: [error]
 		},
 		{
 			code: `
@@ -171,7 +161,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.not(expression, \`foo\${bar}\`);
 				});
 			`,
-			errors: [errorTemplate]
+			errors: [error]
 		},
 		{
 			code: `
@@ -186,7 +176,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.not(\`foo\${bar}\`, expression);
 				});
 			`,
-			errors: [errorTemplate]
+			errors: [error]
 		},
 		{
 			code: `
@@ -201,7 +191,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.is(expression, null);
 				});
 			`,
-			errors: [errorLiteral]
+			errors: [error]
 		},
 		{
 			code: `
@@ -216,7 +206,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.is(null, expression);
 				});
 			`,
-			errors: [errorLiteral]
+			errors: [error]
 		},
 		{
 			code: `
@@ -231,7 +221,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.not(expression, null);
 				});
 			`,
-			errors: [errorLiteral]
+			errors: [error]
 		},
 		{
 			code: `
@@ -246,7 +236,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.not(null, expression);
 				});
 			`,
-			errors: [errorLiteral]
+			errors: [error]
 		},
 		{
 			code: `
@@ -261,7 +251,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.is(expression, undefined);
 				});
 			`,
-			errors: [errorUndefined]
+			errors: [error]
 		},
 		{
 			code: `
@@ -276,7 +266,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.is(undefined, expression);
 				});
 			`,
-			errors: [errorUndefined]
+			errors: [error]
 		},
 		{
 			code: `
@@ -291,7 +281,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.not(expression, undefined);
 				});
 			`,
-			errors: [errorUndefined]
+			errors: [error]
 		},
 		{
 			code: `
@@ -306,7 +296,7 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 					t.not(undefined, expression);
 				});
 			`,
-			errors: [errorUndefined]
+			errors: [error]
 		}
 	]
 });

--- a/test/no-incorrect-deep-equal.js
+++ b/test/no-incorrect-deep-equal.js
@@ -56,13 +56,13 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 		{
 			code: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.deepEqual(expression, 'foo');
 				});
 			`,
 			output: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.is(expression, 'foo');
 				});
 			`,
@@ -71,13 +71,28 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 		{
 			code: `
 				${header}
-				test(t => {
+				test('x', t => {
+					t.deepEqual('foo', expression);
+				});
+			`,
+			output: `
+				${header}
+				test('x', t => {
+					t.is('foo', expression);
+				});
+			`,
+			errors: [errorLiteral]
+		},
+		{
+			code: `
+				${header}
+				test('x', t => {
 					t.notDeepEqual(expression, 'foo');
 				});
 			`,
 			output: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.not(expression, 'foo');
 				});
 			`,
@@ -86,13 +101,28 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 		{
 			code: `
 				${header}
-				test(t => {
+				test('x', t => {
+					t.notDeepEqual('foo', expression);
+				});
+			`,
+			output: `
+				${header}
+				test('x', t => {
+					t.not('foo', expression);
+				});
+			`,
+			errors: [errorLiteral]
+		},
+		{
+			code: `
+				${header}
+				test('x', t => {
 					t.deepEqual(expression, 1);
 				});
 			`,
 			output: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.is(expression, 1);
 				});
 			`,
@@ -101,13 +131,13 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 		{
 			code: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.deepEqual(expression, \`foo\${bar}\`);
 				});
 			`,
 			output: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.is(expression, \`foo\${bar}\`);
 				});
 			`,
@@ -116,13 +146,28 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 		{
 			code: `
 				${header}
-				test(t => {
+				test('x', t => {
+					t.deepEqual(\`foo\${bar}\`, expression);
+				});
+			`,
+			output: `
+				${header}
+				test('x', t => {
+					t.is(\`foo\${bar}\`, expression);
+				});
+			`,
+			errors: [errorTemplate]
+		},
+		{
+			code: `
+				${header}
+				test('x', t => {
 					t.notDeepEqual(expression, \`foo\${bar}\`);
 				});
 			`,
 			output: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.not(expression, \`foo\${bar}\`);
 				});
 			`,
@@ -131,13 +176,28 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 		{
 			code: `
 				${header}
-				test(t => {
+				test('x', t => {
+					t.notDeepEqual(\`foo\${bar}\`, expression);
+				});
+			`,
+			output: `
+				${header}
+				test('x', t => {
+					t.not(\`foo\${bar}\`, expression);
+				});
+			`,
+			errors: [errorTemplate]
+		},
+		{
+			code: `
+				${header}
+				test('x', t => {
 					t.deepEqual(expression, null);
 				});
 			`,
 			output: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.is(expression, null);
 				});
 			`,
@@ -146,13 +206,28 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 		{
 			code: `
 				${header}
-				test(t => {
+				test('x', t => {
+					t.deepEqual(null, expression);
+				});
+			`,
+			output: `
+				${header}
+				test('x', t => {
+					t.is(null, expression);
+				});
+			`,
+			errors: [errorLiteral]
+		},
+		{
+			code: `
+				${header}
+				test('x', t => {
 					t.notDeepEqual(expression, null);
 				});
 			`,
 			output: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.not(expression, null);
 				});
 			`,
@@ -161,13 +236,28 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 		{
 			code: `
 				${header}
-				test(t => {
+				test('x', t => {
+					t.notDeepEqual(null, expression);
+				});
+			`,
+			output: `
+				${header}
+				test('x', t => {
+					t.not(null, expression);
+				});
+			`,
+			errors: [errorLiteral]
+		},
+		{
+			code: `
+				${header}
+				test('x', t => {
 					t.deepEqual(expression, undefined);
 				});
 			`,
 			output: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.is(expression, undefined);
 				});
 			`,
@@ -176,14 +266,44 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 		{
 			code: `
 				${header}
-				test(t => {
+				test('x', t => {
+					t.deepEqual(undefined, expression);
+				});
+			`,
+			output: `
+				${header}
+				test('x', t => {
+					t.is(undefined, expression);
+				});
+			`,
+			errors: [errorUndefined]
+		},
+		{
+			code: `
+				${header}
+				test('x', t => {
 					t.notDeepEqual(expression, undefined);
 				});
 			`,
 			output: `
 				${header}
-				test(t => {
+				test('x', t => {
 					t.not(expression, undefined);
+				});
+			`,
+			errors: [errorUndefined]
+		},
+		{
+			code: `
+				${header}
+				test('x', t => {
+					t.notDeepEqual(undefined, expression);
+				});
+			`,
+			output: `
+				${header}
+				test('x', t => {
+					t.not(undefined, expression);
 				});
 			`,
 			errors: [errorUndefined]

--- a/test/no-incorrect-deep-equal.js
+++ b/test/no-incorrect-deep-equal.js
@@ -1,0 +1,192 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-incorrect-deep-equal';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+const errorLiteral = {
+	ruleId: 'no-incorrect-deep-equal',
+	messageId: 'no-deep-equal-with-literal'
+};
+
+const errorTemplate = {
+	ruleId: 'no-incorrect-deep-equal',
+	messageId: 'no-deep-equal-with-template'
+};
+
+const errorUndefined = {
+	ruleId: 'no-incorrect-deep-equal',
+	messageId: 'no-deep-equal-with-undefined'
+};
+
+const header = 'const test = require(\'ava\');\n';
+
+ruleTester.run('no-incorrect-deep-equal', rule, {
+	valid: [
+		`
+			${header}
+			test(t => {
+				t.deepEqual(expression, otherExpression);
+			});
+		`,
+		`
+			${header}
+			test(t => {
+				t.deepEqual(expression, {});
+			});
+		`,
+		`
+			${header}
+			test(t => {
+				t.deepEqual(expression, []);
+			});
+		`,
+		`
+			${header}
+			test(t => {
+				t.notDeepEqual(expression, []);
+			});
+		`
+	],
+	invalid: [
+		{
+			code: `
+				${header}
+				test(t => {
+					t.deepEqual(expression, 'foo');
+				});
+			`,
+			output: `
+				${header}
+				test(t => {
+					t.is(expression, 'foo');
+				});
+			`,
+			errors: [errorLiteral]
+		},
+		{
+			code: `
+				${header}
+				test(t => {
+					t.notDeepEqual(expression, 'foo');
+				});
+			`,
+			output: `
+				${header}
+				test(t => {
+					t.not(expression, 'foo');
+				});
+			`,
+			errors: [errorLiteral]
+		},
+		{
+			code: `
+				${header}
+				test(t => {
+					t.deepEqual(expression, 1);
+				});
+			`,
+			output: `
+				${header}
+				test(t => {
+					t.is(expression, 1);
+				});
+			`,
+			errors: [errorLiteral]
+		},
+		{
+			code: `
+				${header}
+				test(t => {
+					t.deepEqual(expression, \`foo\${bar}\`);
+				});
+			`,
+			output: `
+				${header}
+				test(t => {
+					t.is(expression, \`foo\${bar}\`);
+				});
+			`,
+			errors: [errorTemplate]
+		},
+		{
+			code: `
+				${header}
+				test(t => {
+					t.notDeepEqual(expression, \`foo\${bar}\`);
+				});
+			`,
+			output: `
+				${header}
+				test(t => {
+					t.not(expression, \`foo\${bar}\`);
+				});
+			`,
+			errors: [errorTemplate]
+		},
+		{
+			code: `
+				${header}
+				test(t => {
+					t.deepEqual(expression, null);
+				});
+			`,
+			output: `
+				${header}
+				test(t => {
+					t.is(expression, null);
+				});
+			`,
+			errors: [errorLiteral]
+		},
+		{
+			code: `
+				${header}
+				test(t => {
+					t.notDeepEqual(expression, null);
+				});
+			`,
+			output: `
+				${header}
+				test(t => {
+					t.not(expression, null);
+				});
+			`,
+			errors: [errorLiteral]
+		},
+		{
+			code: `
+				${header}
+				test(t => {
+					t.deepEqual(expression, undefined);
+				});
+			`,
+			output: `
+				${header}
+				test(t => {
+					t.is(expression, undefined);
+				});
+			`,
+			errors: [errorUndefined]
+		},
+		{
+			code: `
+				${header}
+				test(t => {
+					t.notDeepEqual(expression, undefined);
+				});
+			`,
+			output: `
+				${header}
+				test(t => {
+					t.not(expression, undefined);
+				});
+			`,
+			errors: [errorUndefined]
+		}
+	]
+});

--- a/test/no-incorrect-deep-equal.js
+++ b/test/no-incorrect-deep-equal.js
@@ -19,25 +19,25 @@ ruleTester.run('no-incorrect-deep-equal', rule, {
 	valid: [
 		`
 			${header}
-			test(t => {
+			test('x', t => {
 				t.deepEqual(expression, otherExpression);
 			});
 		`,
 		`
 			${header}
-			test(t => {
+			test('x', t => {
 				t.deepEqual(expression, {});
 			});
 		`,
 		`
 			${header}
-			test(t => {
+			test('x', t => {
 				t.deepEqual(expression, []);
 			});
 		`,
 		`
 			${header}
-			test(t => {
+			test('x', t => {
 				t.notDeepEqual(expression, []);
 			});
 		`


### PR DESCRIPTION
Closes #158.

Does not cover `t.deepEqual(1, expression); // ?` situations. Does not fix back to `deepEqual` if it detects a non-literal in `is` -- I felt that would be an ambiguous situation in the event that someone actually wanted to compare by reference.
