### PR TITLE
Add missing period in some rule messages

### DIFF
--- a/rules/no-nested-tests.js
+++ b/rules/no-nested-tests.js
@@ -16,7 +16,7 @@ const create = context => {
 			if (nestedCount >= 2) {
 				context.report({
 					node,
-					message: 'Tests should not be nested'
+					message: 'Tests should not be nested.'
 				});
 			}
 		}),

--- a/rules/test-title-format.js
+++ b/rules/test-title-format.js
@@ -27,7 +27,7 @@ const create = context => {
 				if (title.type === 'Literal' && !titleRegExp.test(title.value)) {
 					context.report({
 						node,
-						message: `The test title doesn't match the required format: \`${titleRegExp}\``
+						message: `The test title doesn't match the required format: \`${titleRegExp}\`.`
 					});
 				}
 			}

--- a/test/no-nested-tests.js
+++ b/test/no-nested-tests.js
@@ -11,7 +11,7 @@ const ruleTester = avaRuleTester(test, {
 const header = 'const test = require(\'ava\');\n';
 const error = {
 	ruleId: 'no-nested-tests',
-	message: 'Tests should not be nested'
+	message: 'Tests should not be nested.'
 };
 
 ruleTester.run('no-nested-tests', rule, {


### PR DESCRIPTION
I've done a grep and it turns out these two rules have missing period in the report message. Now I add them for consistency.