### PR TITLE
Remove handling of isSource classification

### DIFF
--- a/docs/rules/no-ignored-test-files.md
+++ b/docs/rules/no-ignored-test-files.md
@@ -44,7 +44,6 @@ This rule supports the following options:
 * `extensions`: an array of extensions of the files that AVA recognizes as test files or helpers. Overrides *both* the `babel.extensions` *and* `extensions` configuration otherwise used by AVA itself.
 * `files`: an array of glob patterns to select test files. Overrides the `files` configuration otherwise used by AVA itself.
 * `helpers`: an array of glob patterns to select helper files. Overrides the `helpers` configuration otherwise used by AVA itself.
-* `sources`: an array of glob patterns to match files that, when changed, cause tests to be re-run (when in watch mode). Overrides the `sources` configuration otherwise used by AVA itself.
 
 See also [AVA's configuration](https://github.com/avajs/ava/blob/master/docs/06-configuration.md#options).
 

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -31,13 +31,11 @@ const create = context => {
 				return {};
 			}
 
-			const {isHelper, isSource, isTest} = avaHelper.classifyFile(filename);
+			const {isHelper, isTest} = avaHelper.classifyFile(filename);
 
 			if (!isTest) {
 				if (isHelper) {
 					context.report({node, message: 'AVA treats this as a helper file.'});
-				} else if (isSource) {
-					context.report({node, message: 'AVA treats this as a source file.'});
 				} else {
 					context.report({node, message: 'AVA ignores this file.'});
 				}

--- a/test/no-ignored-test-files.js
+++ b/test/no-ignored-test-files.js
@@ -20,13 +20,13 @@ util.loadAvaHelper = () => ({
 	classifyFile: file => {
 		switch (file) {
 			case toPath('lib/foo.test.js'):
-				return {isHelper: false, isSource: false, isTest: true};
+				return {isHelper: false, isTest: true};
 			case toPath('lib/foo/fixtures/bar.test.js'):
-				return {isHelper: false, isSource: true, isTest: false};
+				return {isHelper: false, isTest: false};
 			case toPath('lib/foo/helpers/bar.test.js'):
-				return {isHelper: true, isSource: false, isTest: false};
+				return {isHelper: true, isTest: false};
 			default:
-				return {isHelper: false, isSource: false, isTest: false};
+				return {isHelper: false, isTest: false};
 		}
 	}
 });
@@ -42,7 +42,7 @@ ruleTester.run('no-ignored-test-files', rule, {
 		{
 			code: code(true),
 			filename: toPath('lib/foo/fixtures/bar.test.js'),
-			errors: [{message: 'AVA treats this as a source file.'}]
+			errors: [{message: 'AVA ignores this file.'}]
 		},
 		{
 			code: code(true),

--- a/test/no-import-test-files.js
+++ b/test/no-import-test-files.js
@@ -20,13 +20,13 @@ util.loadAvaHelper = () => ({
 	classifyImport: importPath => {
 		switch (importPath) {
 			case toPath('lib/foo.test.js'):
-				return {isHelper: false, isSource: false, isTest: true};
+				return {isHelper: false, isTest: true};
 			case toPath('../foo.test.js'):
-				return {isHelper: false, isSource: false, isTest: true};
+				return {isHelper: false, isTest: true};
 			case toPath('@foo/bar'): // Regression test for https://github.com/avajs/eslint-plugin-ava/issues/253
-				return {isHelper: false, isSource: false, isTest: true};
+				return {isHelper: false, isTest: true};
 			default:
-				return {isHelper: false, isSource: false, isTest: false};
+				return {isHelper: false, isTest: false};
 		}
 	}
 });


### PR DESCRIPTION
This is being removed from AVA 3, see https://github.com/avajs/ava/pull/2323.