### PR TITLE
Use CJS syntax in documentation

### DIFF
--- a/docs/rules/assertion-arguments.md
+++ b/docs/rules/assertion-arguments.md
@@ -9,7 +9,7 @@ Assertion messages are optional arguments that can be given to any assertion cal
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(t => {
 	t.is(value); // Not enough arguments
@@ -31,7 +31,7 @@ test(t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(t => {
 	t.is(value, expected);

--- a/docs/rules/hooks-order.md
+++ b/docs/rules/hooks-order.md
@@ -18,7 +18,7 @@ This rule is fixable as long as no other code is between the hooks that need to 
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.after(t => {
 	doFoo();
@@ -34,7 +34,7 @@ test('foo', t => {
 ```
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.true(true);
@@ -49,7 +49,7 @@ test.before(t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.before(t => {
 	doFoo();

--- a/docs/rules/max-asserts.md
+++ b/docs/rules/max-asserts.md
@@ -11,7 +11,7 @@ Skipped assertions are counted.
 
 ```js
 /*eslint ava/max-asserts: ["error", 5]*/
-import test from 'ava';
+const test = require('ava');
 
 test('getSomeObject should define the players\' names', t => {
 	const object = lib.getSomeObject();
@@ -30,7 +30,7 @@ test('getSomeObject should define the players\' names', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('getSomeObject should define the player\'s name', t => {
 	const object = lib.getSomeObject();

--- a/docs/rules/no-async-fn-without-await.md
+++ b/docs/rules/no-async-fn-without-await.md
@@ -12,7 +12,7 @@ This rule will report an error when it finds an async test which does not use th
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(async t => {
 	return foo().then(res => {
@@ -25,7 +25,7 @@ test(async t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(async t => {
 	t.is(await foo(), 1);

--- a/docs/rules/no-cb-test.md
+++ b/docs/rules/no-cb-test.md
@@ -8,7 +8,7 @@ Disallow the use of `test.cb()`. We instead recommend using `test()` with an asy
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.cb('some test', t => {
 	t.pass();
@@ -20,7 +20,7 @@ test.cb('some test', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('some test', async t => {
 	t.pass();

--- a/docs/rules/no-duplicate-modifiers.md
+++ b/docs/rules/no-duplicate-modifiers.md
@@ -8,7 +8,7 @@ Prevent the use of duplicate [test modifiers](https://github.com/avajs/ava/blob/
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.only.only(t => {});
 test.serial.serial(t => {});
@@ -21,7 +21,7 @@ test.only.only.cb(t => {});
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.only(t => {});
 test.serial(t => {});

--- a/docs/rules/no-identical-title.md
+++ b/docs/rules/no-identical-title.md
@@ -8,7 +8,7 @@ Disallow tests with identical titles as it makes it hard to differentiate them.
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.pass();
@@ -23,7 +23,7 @@ test('foo', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(t => {
 	t.pass();

--- a/docs/rules/no-ignored-test-files.md
+++ b/docs/rules/no-ignored-test-files.md
@@ -10,7 +10,7 @@ This rule will verify that files which create tests are treated as test files by
 ```js
 // File: test/_helper.js
 // Invalid because a helper.
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.pass();
@@ -18,7 +18,7 @@ test('foo', t => {
 
 // File: lib/foo.js
 // Invalid because not a test file.
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.pass();
@@ -30,7 +30,7 @@ test('foo', t => {
 
 ```js
 // File: test/foo.js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.pass();

--- a/docs/rules/no-import-test-files.md
+++ b/docs/rules/no-import-test-files.md
@@ -10,13 +10,13 @@ This rule will verify that you don't import any test files. It will consider the
 ```js
 // File: src/index.js
 // Invalid because *.test.js is considered as a test file.
-import tests from './index.test.js';
+const tests = require('./index.test.js');
 ```
 
 ```js
 // File: src/index.js
 // Invalid because any files inside __tests__ are considered test files
-import tests from './__tests__/index.js';
+const tests = require('./__tests__/index.js');
 
 test('foo', t => {
 	t.pass();
@@ -28,13 +28,13 @@ test('foo', t => {
 
 ```js
 // File: src/index.js
-import sinon from 'sinon';
+const sinon = require('sinon');
 
 ```
 
 ```js
 // File: src/index.js
-import utils from './utils';
+const utils = require('./utils');
 ```
 
 ## Options

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -10,7 +10,7 @@ This rule is fixable. It will wrap the assertion in braces `{}`. It will not do 
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => t.true(fn()));
 ```
@@ -19,7 +19,7 @@ test('foo', t => t.true(fn()));
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.true(fn());

--- a/docs/rules/no-invalid-end.md
+++ b/docs/rules/no-invalid-end.md
@@ -8,7 +8,7 @@ AVA will fail if `t.end()` is called in a non-`.cb` test function.
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('some test', t => {
 	t.pass();
@@ -20,7 +20,7 @@ test('some test', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('some test', t => {
 	t.pass();

--- a/docs/rules/no-nested-tests.md
+++ b/docs/rules/no-nested-tests.md
@@ -8,7 +8,7 @@ In AVA, you cannot nest tests, for example, create tests inside of other tests. 
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	const result = foo();
@@ -24,7 +24,7 @@ test('foo', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	const result = foo();

--- a/docs/rules/no-only-test.md
+++ b/docs/rules/no-only-test.md
@@ -4,13 +4,13 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/re
 
 It's easy to run only one test with `test.only()` and then forget about it. It's visible in the results, but still easily missed. Forgetting to remove `.only`, means only this one test in the whole file will run, and if not caught, can let serious bugs slip into your codebase.
 
-This rule is fixable. It will remove the `.only` test modifier. 
+This rule is fixable. It will remove the `.only` test modifier.
 
 
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.only('test 1', t => {
 	t.pass();
@@ -26,7 +26,7 @@ test('test 2', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('test 1', t => {
 	t.pass();

--- a/docs/rules/no-skip-assert.md
+++ b/docs/rules/no-skip-assert.md
@@ -8,7 +8,7 @@ It's easy to make an assertion skipped with `t.skip.xyz()` and then forget about
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('some title', t => {
 	t.skip.is(1, 1);
@@ -19,7 +19,7 @@ test('some title', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('some title', t => {
 	t.is(1, 1);

--- a/docs/rules/no-skip-test.md
+++ b/docs/rules/no-skip-test.md
@@ -10,7 +10,7 @@ This rule is fixable. It will remove the `.skip` test modifier.
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.pass();
@@ -25,7 +25,7 @@ test.skip('bar', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.pass();

--- a/docs/rules/no-statement-after-end.md
+++ b/docs/rules/no-statement-after-end.md
@@ -7,7 +7,7 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/re
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.cb(t => {
 	t.end();
@@ -24,13 +24,13 @@ test.cb(t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.cb(t => {
 	t.is(1, 1);
 	t.end();
 });
-import test from 'ava';
+const test = require('ava');
 
 test.cb(t => {
 	if (a) {

--- a/docs/rules/no-todo-implementation.md
+++ b/docs/rules/no-todo-implementation.md
@@ -8,7 +8,7 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/re
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.todo('title', t => {
 	// ...
@@ -23,7 +23,7 @@ test.todo(t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.todo('title');
 

--- a/docs/rules/no-todo-test.md
+++ b/docs/rules/no-todo-test.md
@@ -8,7 +8,7 @@ Disallow the use of `test.todo()`. You might want to do this to only ship featur
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.todo('some test');
 ```
@@ -17,7 +17,7 @@ test.todo('some test');
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('some test', t => {
 	// Some implementation

--- a/docs/rules/no-unknown-modifiers.md
+++ b/docs/rules/no-unknown-modifiers.md
@@ -8,7 +8,7 @@ Prevent the use of unknown [test modifiers](https://github.com/avajs/ava/blob/ma
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.onlu(t => {});
 test.seril(t => {});
@@ -21,7 +21,7 @@ test.unknown(t => {});
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.only(t => {});
 test.serial(t => {});

--- a/docs/rules/prefer-async-await.md
+++ b/docs/rules/prefer-async-await.md
@@ -10,7 +10,7 @@ This rule will report an error when it finds a test that returns an expression t
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(t => {
 	return foo().then(res => {
@@ -23,7 +23,7 @@ test(t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(async t => {
 	t.is(await foo(), 1);

--- a/docs/rules/prefer-power-assert.md
+++ b/docs/rules/prefer-power-assert.md
@@ -16,7 +16,7 @@ Useful for people wanting to fully embrace the power of [power-assert](https://g
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(t => {
 	t.truthy(foo);
@@ -34,7 +34,7 @@ test(t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(t => {
 	t.assert(foo === bar);

--- a/docs/rules/prefer-t-regex.md
+++ b/docs/rules/prefer-t-regex.md
@@ -12,7 +12,7 @@ This rule is fixable. It will replace the use of `RegExp#test()`, `String#match(
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('main', t => {
 	t.true(/\w+/.test('foo'));
@@ -20,7 +20,7 @@ test('main', t => {
 ```
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('main', t => {
 	t.truthy('foo'.match(/\w+/));
@@ -31,7 +31,7 @@ test('main', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('main', async t => {
 	t.regex('foo', /\w+/);

--- a/docs/rules/test-ended.md
+++ b/docs/rules/test-ended.md
@@ -8,7 +8,7 @@ If you forget a `t.end();` in `test.cb()` the test will hang indefinitely.
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.cb(t => {
 	t.pass();
@@ -19,7 +19,7 @@ test.cb(t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test.cb(t => {
 	t.pass();

--- a/docs/rules/test-title-format.md
+++ b/docs/rules/test-title-format.md
@@ -11,7 +11,7 @@ For example, titles like `'Should throw when invalid.'`, `'Should fail when call
 
 ```js
 /* eslint ava/test-title-format: ["error", {format: "^Should"}] */
-import test from 'ava';
+const test = require('ava');
 
 test('Not starting with `Should`', t => {
 	t.pass();
@@ -20,7 +20,7 @@ test('Not starting with `Should`', t => {
 
 ```js
 /* eslint ava/test-title-format: ["error", {format: "\\.$"}] */
-import test from 'ava';
+const test = require('ava');
 
 test('Doesn\'t end with a dot', t => {
 	t.pass();
@@ -32,7 +32,7 @@ test('Doesn\'t end with a dot', t => {
 
 ```js
 /* eslint ava/test-title-format: ["error", {format: "^Should"}] */
-import test from 'ava';
+const test = require('ava');
 
 test('Should pass tests', t => {
 	t.pass();
@@ -45,7 +45,7 @@ test('Should behave as expected', t => {
 
 ```js
 /* eslint ava/test-title-format: ["error", {format: "\\.$"}] */
-import test from 'ava';
+const test = require('ava');
 
 test('End with a dot.', t => {
 	t.pass();

--- a/docs/rules/test-title.md
+++ b/docs/rules/test-title.md
@@ -8,7 +8,7 @@ Tests should have a title. AVA [v1.0.1](https://github.com/avajs/ava/releases/ta
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(t => {
 	t.pass();
@@ -19,7 +19,7 @@ test(t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.pass();

--- a/docs/rules/use-t-well.md
+++ b/docs/rules/use-t-well.md
@@ -10,7 +10,7 @@ This rule is partly fixable. It will replace misspelled `.falsey` with `.falsy`.
 ## Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('main', t => {
 	t(value); // `t` is not a function
@@ -27,7 +27,7 @@ test('main', t => {
 ## Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('main', t => {
 	t.deepEqual(value, [2]);

--- a/docs/rules/use-t.md
+++ b/docs/rules/use-t.md
@@ -7,7 +7,7 @@ The convention is to have the parameter in AVA's test function be named `t`. Mos
 ### Fail
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(foo => { // Incorrect name
 	t.pass();
@@ -25,7 +25,7 @@ test((bar, t) => { // too many arguments
 ### Pass
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test(() => {
 	// ...

--- a/docs/rules/use-test.md
+++ b/docs/rules/use-test.md
@@ -22,5 +22,5 @@ const test = require('ava');
 import test from 'ava';
 
 var test = require('foo');
-import test from 'foo';
+const test = require('foo');
 ```

--- a/docs/rules/use-true-false.md
+++ b/docs/rules/use-true-false.md
@@ -9,7 +9,7 @@ This rule enforces the use of the former when the tested expression is known to 
 ### Fail
 
 ```js
-import ava from 'ava';
+const ava = require('ava');
 
 test(t => {
 	t.truthy(value < 2);
@@ -24,7 +24,7 @@ test(t => {
 ### Pass
 
 ```js
-import ava from 'ava';
+const ava = require('ava');
 
 test(t => {
 	t.true(value < 2);


### PR DESCRIPTION
Out of the box, ESM syntax will only work in Node.js 13, so having that
as the default example is misleading.
