### PR TITLE
Allow importing AVA as `anyTest` in TypeScript files

### DIFF
--- a/docs/rules/use-test.md
+++ b/docs/rules/use-test.md
@@ -3,7 +3,7 @@
 Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/related/eslint-plugin-ava/docs/rules/use-test.md)
 
 The convention is to import AVA and assign it to a variable named `test`. Most rules in `eslint-plugin-ava` are based on that assumption.
-In a TypeScript file (`.ts` or `.tsx`) AVA can be assign to to a variable named `anyTest` in order to define the types of `t.context` (see [Typing t.context](https://github.com/avajs/ava/blob/master/docs/recipes/typescript.md#typing-tcontext)).
+In a TypeScript file (`.ts` or `.tsx`) AVA can be assigned to a variable named `anyTest` in order to define the types of `t.context` (see [Typing t.context](https://github.com/avajs/ava/blob/master/docs/recipes/typescript.md#typing-tcontext)).
 
 ### Fail
 

--- a/docs/rules/use-test.md
+++ b/docs/rules/use-test.md
@@ -3,6 +3,7 @@
 Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/related/eslint-plugin-ava/docs/rules/use-test.md)
 
 The convention is to import AVA and assign it to a variable named `test`. Most rules in `eslint-plugin-ava` are based on that assumption.
+In a TypeScript file (`.ts` or `.tsx`) AVA can be assign to to a variable named `anyTest` in order to define the types of `t.context` (see [Typing t.context](https://github.com/avajs/ava/blob/master/docs/recipes/typescript.md#typing-tcontext)).
 
 ### Fail
 
@@ -23,4 +24,10 @@ import test from 'ava';
 
 var test = require('foo');
 const test = require('foo');
+```
+
+```ts
+import anyTest from 'ava';
+
+const test = anyTest as TestInterface<{foo: string}>;
 ```

--- a/rules/use-test.js
+++ b/rules/use-test.js
@@ -32,7 +32,7 @@ const create = context => {
 	return {
 		ImportDeclaration: node => {
 			if (node.source.value === 'ava') {
-				const {name} = node.specifiers[0].local
+				const {name} = node.specifiers[0].local;
 				if (name !== 'test' && (!isTypeScript || name !== 'anyTest')) {
 					report(context, node);
 				}

--- a/rules/use-test.js
+++ b/rules/use-test.js
@@ -26,19 +26,24 @@ function report(context, node) {
 }
 
 const create = context => {
-	const isTypescript = ['.ts', '.tsx'].includes(path.extname(context.getFilename()));
+	const ext = path.extname(context.getFilename());
+	const isTypeScript = ext === '.ts' || ext === '.tsx';
 
 	return {
 		ImportDeclaration: node => {
-			if (node.source.value === 'ava' &&
-				!['test', ...(isTypescript ? ['anyTest'] : [])].includes(node.specifiers[0].local.name)) {
-				report(context, node);
+			if (node.source.value === 'ava') {
+				const {name} = node.specifiers[0].local
+				if (name !== 'test' && (!isTypeScript || name !== 'anyTest')) {
+					report(context, node);
+				}
 			}
 		},
 		VariableDeclarator: node => {
-			if (!['test', ...(isTypescript ? ['anyTest'] : [])].includes(node.id.name) &&
-				node.init && deepStrictEqual(espurify(node.init), avaVariableDeclaratorInitAst)) {
-				report(context, node);
+			if (node.init && deepStrictEqual(espurify(node.init), avaVariableDeclaratorInitAst)) {
+				const {name} = node.id;
+				if (name !== 'test' && (!isTypeScript || name !== 'anyTest')) {
+					report(context, node);
+				}
 			}
 		}
 	};

--- a/test/use-test.js
+++ b/test/use-test.js
@@ -15,35 +15,111 @@ const errors = [{ruleId: 'use-test'}];
 
 ruleTester.run('use-test', rule, {
 	valid: [
-		'var test = require(\'ava\');',
-		'let test = require(\'ava\');',
-		'const test = require(\'ava\');',
-		'const a = 1, test = require(\'ava\'), b = 2;',
-		'const test = require(\'foo\');',
-		'import test from \'ava\';',
-		'import test, {} from \'ava\';',
-		'import test from \'foo\';'
+		{code: 'var test = require(\'ava\');', filename: 'file.js'},
+		{code: 'let test = require(\'ava\');', filename: 'file.js'},
+		{code: 'const test = require(\'ava\');', filename: 'file.js'},
+		{code: 'const a = 1, test = require(\'ava\'), b = 2;', filename: 'file.js'},
+		{code: 'const test = require(\'foo\');', filename: 'file.js'},
+		{code: 'import test from \'ava\';', filename: 'file.js'},
+		{code: 'import test, {} from \'ava\';', filename: 'file.js'},
+		{code: 'import test from \'foo\';', filename: 'file.js'},
+		{code: 'var anyTest = require(\'ava\');', filename: 'file.ts'},
+		{code: 'let anyTest = require(\'ava\');', filename: 'file.ts'},
+		{code: 'const anyTest = require(\'ava\');', filename: 'file.ts'},
+		{code: 'const a = 1, anyTest = require(\'ava\'), b = 2;', filename: 'file.ts'},
+		{code: 'const anyTest = require(\'foo\');', filename: 'file.ts'},
+		{code: 'import anyTest from \'ava\';', filename: 'file.ts'},
+		{code: 'import anyTest, {} from \'ava\';', filename: 'file.ts'},
+		{code: 'import anyTest from \'foo\';', filename: 'file.ts'},
+		{code: 'var anyTest = require(\'ava\');', filename: 'file.tsx'},
+		{code: 'let anyTest = require(\'ava\');', filename: 'file.tsx'},
+		{code: 'const anyTest = require(\'ava\');', filename: 'file.tsx'},
+		{code: 'const a = 1, anyTest = require(\'ava\'), b = 2;', filename: 'file.tsx'},
+		{code: 'const anyTest = require(\'foo\');', filename: 'file.tsx'},
+		{code: 'import anyTest from \'ava\';', filename: 'file.tsx'},
+		{code: 'import anyTest, {} from \'ava\';', filename: 'file.tsx'},
+		{code: 'import anyTest from \'foo\';', filename: 'file.tsx'}
 	],
 	invalid: [
 		{
 			code: 'var ava = require(\'ava\');',
-			errors
+			errors,
+			filename: 'file.ts'
 		},
 		{
 			code: 'let ava = require(\'ava\');',
-			errors
+			errors,
+			filename: 'file.ts'
 		},
 		{
 			code: 'const ava = require(\'ava\');',
-			errors
+			errors,
+			filename: 'file.ts'
 		},
 		{
 			code: 'const a = 1, ava = require(\'ava\'), b = 2;',
-			errors
+			errors,
+			filename: 'file.ts'
 		},
 		{
 			code: 'import ava from \'ava\';',
-			errors
+			errors,
+			filename: 'file.ts'
+		},
+		{
+			code: 'var anyTest = require(\'ava\');',
+			errors,
+			filename: 'file.js'
+		},
+		{
+			code: 'var ava = require(\'ava\');',
+			errors,
+			filename: 'file.ts'
+		},
+		{
+			code: 'let ava = require(\'ava\');',
+			errors,
+			filename: 'file.ts'
+		},
+		{
+			code: 'const ava = require(\'ava\');',
+			errors,
+			filename: 'file.ts'
+		},
+		{
+			code: 'const a = 1, ava = require(\'ava\'), b = 2;',
+			errors,
+			filename: 'file.ts'
+		},
+		{
+			code: 'import ava from \'ava\';',
+			errors,
+			filename: 'file.ts'
+		},
+		{
+			code: 'var ava = require(\'ava\');',
+			errors,
+			filename: 'file.tsx'
+		},
+		{
+			code: 'let ava = require(\'ava\');',
+			errors,
+			filename: 'file.tsx'
+		},
+		{
+			code: 'const ava = require(\'ava\');',
+			errors,
+			filename: 'file.tsx'
+		},
+		{
+			code: 'const a = 1, ava = require(\'ava\'), b = 2;',
+			errors,
+			filename: 'file.tsx'
+		},
+		{
+			code: 'import ava from \'ava\';',
+			errors,
+			filename: 'file.tsx'
 		}
 	]
 });


### PR DESCRIPTION
Fix #293 

Change `use-test` to allow importing AVA as `anyTest` in order to account for the example in [Typing t.context](https://github.com/avajs/ava/blob/master/docs/recipes/typescript.md#typing-tcontext).

This change could be further improved by making sure that when AVA is imported as `any` it is assigned to a variable name `test`, e.g:
```
const test = anyTest as TestInterface<{foo: string}>;
```

In other words the following should be invalid:
```
import anyTest, {TestInterface} from 'ava';

const myTest = anyTest as TestInterface<{foo: string}>;
```

That's important because some other rules depends on the AVA object to be named `test`. However, the change in that PR is still better than forcing users to disable the rules.

Implementing such validation is beyond my knowledge of ESLint aPI though...