### PR TITLE
Add equality checks to `prefer-t-regex` rule

### DIFF
--- a/docs/rules/prefer-t-regex.md
+++ b/docs/rules/prefer-t-regex.md
@@ -4,7 +4,7 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/re
 
 The AVA [`t.regex()` assertion](https://github.com/avajs/ava/blob/master/docs/03-assertions.md#regexcontents-regex-message) can test a string against a regular expression.
 
-This rule will enforce the use of `t.regex()` instead of manually using `RegExp#test()`, which will make your code look clearer and produce better failure output.
+This rule will enforce the use of `t.regex()` instead of manually using `RegExp#test()`, which will make your code look clearer and produce better failure output. The rule will also prevent equality assertions with a regex and a non-regex, which is almost always an error.
 
 This rule is fixable. It will replace the use of `RegExp#test()`, `String#match()`, or `String#search()` with `t.regex()`.
 
@@ -24,6 +24,14 @@ const test = require('ava');
 
 test('main', t => {
 	t.truthy('foo'.match(/\w+/));
+});
+```
+
+```js
+const test = require('ava');
+
+test('main', t => {
+	t.is('foo', /\w+/);
 });
 ```
 

--- a/rules/prefer-t-regex.js
+++ b/rules/prefer-t-regex.js
@@ -34,7 +34,7 @@ const create = context => {
 		if (!isRegex && lookup.type === 'Identifier') {
 			const reference = findReference(lookup.name);
 
-			// Not all possible references have an init field§
+			// Not all possible references have an init field
 			if (reference && reference.init) {
 				isRegex = reference.init.regex;
 			}
@@ -91,10 +91,6 @@ const create = context => {
 		const firstArg = node.arguments[0];
 		const secondArg = node.arguments[1];
 
-		if (!firstArg || !secondArg) {
-			return;
-		}
-
 		const firstIsRx = isRegExp(firstArg);
 		const secondIsRx = isRegExp(secondArg);
 
@@ -111,7 +107,7 @@ const create = context => {
 		const fix = fixer => {
 			const source = context.getSourceCode();
 			return [
-				fixer.replaceText(node.callee.property, 'regex'),
+				fixer.replaceText(node.callee.property, assertion),
 				fixer.replaceText(firstArg, `${source.getText(matchee)}`),
 				fixer.replaceText(secondArg, `${source.getText(regex)}`)
 			];

--- a/rules/prefer-t-regex.js
+++ b/rules/prefer-t-regex.js
@@ -88,19 +88,18 @@ const create = context => {
 	};
 
 	const equalityHandler = node => {
-		const firstArg = node.arguments[0];
-		const secondArg = node.arguments[1];
+		const [firstArg, secondArg] = node.arguments;
 
-		const firstIsRx = isRegExp(firstArg);
-		const secondIsRx = isRegExp(secondArg);
+		const firstArgumentIsRegex = isRegExp(firstArg);
+		const secondArgumentIsRegex = isRegExp(secondArg);
 
 		// If both are regex, or neither are, the expression is ok
-		if (firstIsRx === secondIsRx) {
+		if (firstArgumentIsRegex === secondArgumentIsRegex) {
 			return;
 		}
 
-		const matchee = secondIsRx ? firstArg : secondArg;
-		const regex = secondIsRx ? secondArg : firstArg;
+		const matchee = secondArgumentIsRegex ? firstArg : secondArg;
+		const regex = secondArgumentIsRegex ? secondArg : firstArg;
 
 		const assertion = 'regex';
 

--- a/test/prefer-t-regex.js
+++ b/test/prefer-t-regex.js
@@ -18,7 +18,7 @@ ruleTester.run('prefer-t-regex', rule, {
 	valid: [
 		header + 'test(t => t.regex("foo", /\\d+/));',
 		header + 'test(t => t.regex(foo(), /\\d+/));',
-		header + 'test(t => t.is(/\\d+/.test("foo")), true);',
+		header + 'test(t => t.is(/\\d+/.test("foo"), true));',
 		header + 'test(t => t.true(1 === 1));',
 		header + 'test(t => t.true(foo.bar()));',
 		header + 'const a = /\\d+/;\ntest(t => t.truthy(a));',
@@ -61,6 +61,26 @@ ruleTester.run('prefer-t-regex', rule, {
 		{
 			code: header + 'const reg = /\\d+/;\ntest(t => t.true(reg.test(foo.bar())));',
 			output: header + 'const reg = /\\d+/;\ntest(t => t.regex(foo.bar(), reg));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.is(foo(), /\\d+/));',
+			output: header + 'test(t => t.regex(foo(), /\\d+/));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.is(/\\d+/, foo()));',
+			output: header + 'test(t => t.regex(foo(), /\\d+/));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.deepEqual(foo(), /\\d+/));',
+			output: header + 'test(t => t.regex(foo(), /\\d+/));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.deepEqual(/\\d+/, foo()));',
+			output: header + 'test(t => t.regex(foo(), /\\d+/));',
 			errors: errors('regex')
 		}
 	]


### PR DESCRIPTION
Fixes #275.

These are the maximal reasonable rules I could think of.

![image](https://user-images.githubusercontent.com/908675/75587751-d8087200-5a7f-11ea-85ee-975ab533dd91.png)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#275: Detect more assertions in the `t-prefer-regex` rule](https://issuehunt.io/repos/49722492/issues/275)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->