### PR TITLE
Allow three snapshot arguments

### DIFF
--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -71,7 +71,7 @@ const expectedNbArguments = {
 	},
 	snapshot: {
 		min: 1,
-		max: 2
+		max: 3
 	},
 	teardown: {
 		min: 1,

--- a/test/assertion-arguments.js
+++ b/test/assertion-arguments.js
@@ -178,6 +178,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, 't.true(true, \'message\');'),
 		testCase(false, 't.truthy(\'unicorn\', \'message\');'),
 		testCase(false, 't.snapshot(value, \'message\');'),
+		testCase(false, 't.snapshot(value, options, \'message\');'),
 		testCase(false, 't.context.plan();'),
 		testCase(false, 't.teardown(() => {});'),
 		testCase(false, 't.timeout(100, \'message\');'),
@@ -209,6 +210,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, 't.true(true);'),
 		testCase(false, 't.truthy(\'unicorn\');'),
 		testCase(false, 't.snapshot(value);'),
+		testCase(false, 't.snapshot(value, options);'),
 		// Shouldn't be triggered since it's not a test file
 		testCase(false, 't.true(true, \'message\');', [], {useHeader: false}),
 
@@ -238,7 +240,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('always', 't.ifError(new Error(), \'message\');'),
 		testCase('always', 't.skip.is(\'same\', \'same\', \'message\');'),
 		testCase('always', 't.is.skip(\'same\', \'same\', \'message\');'),
-		testCase('always', 't.snapshot(value, \'message\');'),
+		testCase('always', 't.snapshot(value, options, \'message\');'),
 		testCase('always', 't.teardown(() => {});'),
 		testCase('always', 't.timeout(100, \'message\');'),
 		testCase('always', 't.try(tt => tt.pass());'),
@@ -277,6 +279,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('never', 't.skip.is(\'same\', \'same\');'),
 		testCase('never', 't.is.skip(\'same\', \'same\');'),
 		testCase('never', 't.snapshot(value);'),
+		testCase('never', 't.snapshot(value, options);'),
 		testCase('never', 't.teardown(() => {});'),
 		testCase('never', 't.timeout(100);'),
 		testCase('never', 't.try(tt => tt.pass());'),
@@ -383,7 +386,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, 't.ifError(new Error(), \'message\', \'extra argument\');', tooManyError(2)),
 		testCase(false, 't.skip.is(\'same\', \'same\', \'message\', \'extra argument\');', tooManyError(3)),
 		testCase(false, 't.is.skip(\'same\', \'same\', \'message\', \'extra argument\');', tooManyError(3)),
-		testCase(false, 't.snapshot(value, \'message\', \'extra argument\');', tooManyError(2)),
+		testCase(false, 't.snapshot(value, options, \'message\', \'extra argument\');', tooManyError(3)),
 		testCase(false, 't.teardown(() => {}, \'extra argument\');', tooManyError(1)),
 		testCase(false, 't.timeout(1, \'message\', \'extra argument\');', tooManyError(2)),
 
@@ -411,6 +414,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('always', 't.skip.is(\'same\', \'same\');', missingError),
 		testCase('always', 't.is.skip(\'same\', \'same\');', missingError),
 		testCase('always', 't.snapshot(value);', missingError),
+		testCase('always', 't.snapshot(value, options);', missingError),
 
 		testCase('never', 't.assert(true, \'message\');', foundError),
 		testCase('never', 't.pass(\'message\');', foundError),
@@ -433,7 +437,7 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase('never', 't.ifError(new Error(), \'message\');', foundError),
 		testCase('never', 't.skip.is(\'same\', \'same\', \'message\');', foundError),
 		testCase('never', 't.is.skip(\'same\', \'same\', \'message\');', foundError),
-		testCase('never', 't.snapshot(value, \'message\');', foundError),
+		testCase('never', 't.snapshot(value, options, \'message\');', foundError),
 
 		testCase(false, 't.end(\'too many\', \'arguments\');', tooManyError(1)),
 		testCase(false, 't.skip.end(\'too many\', \'arguments\');', tooManyError(1)),


### PR DESCRIPTION
According to the AVA [documentation for `.snapshot()`](https://github.com/avajs/ava/blob/master/docs/03-assertions.md#snapshotexpected-options-message) it can accept three argument

`.snapshot(expected, options?, message?)`

The current lint rules don't allow using `.snapshot()` with the third argument. This PR updates the rule so the third argument is allowed

One thing I noticed putting this together, I had to change the number of arguments in some of the test assertions as they were failing. I'm not sure if this is correct, but it appears the same is done for `.throws()`? Happy to make any changes