### PR TITLE
Ensure the assertion message is a string

### DIFF
--- a/docs/rules/assertion-arguments.md
+++ b/docs/rules/assertion-arguments.md
@@ -16,6 +16,7 @@ const test = require('ava');
 test(t => {
 	t.is(value); // Not enough arguments
 	t.is(value, expected, message, extra); // Too many arguments
+	t.is(value, expected, false); // Assertion message is not a string
 });
 
 /* eslint ava/assertion-arguments: ["error", {"message": "always"}] */

--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -284,10 +284,11 @@ const create = context => {
 
 				if (lastArg.type === 'Identifier') {
 					const variable = findVariable(context.getScope(), lastArg);
-					let value = null;
-					variable.references.forEach(ref => {
+					let value;
+					for (const ref of variable.references) {
 						value = ref.writeExpr || value;
-					});
+					}
+
 					lastArg = value;
 				}
 

--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -1,6 +1,6 @@
 'use strict';
 const {visitIf} = require('enhance-visitors');
-const {getStaticValue, isOpeningParenToken, isCommaToken} = require('eslint-utils');
+const {getStaticValue, isOpeningParenToken, isCommaToken, findVariable} = require('eslint-utils');
 const util = require('../util');
 const createAvaRule = require('../create-ava-rule');
 
@@ -203,6 +203,13 @@ function noComments(sourceCode, ...nodes) {
 	});
 }
 
+function isString(node) {
+	const {type} = node;
+	return type === 'TemplateLiteral' ||
+		type === 'TaggedTemplateExpression' ||
+		(type === 'Literal' && typeof node.value === 'string');
+}
+
 const create = context => {
 	const ava = createAvaRule();
 	const options = context.options[0] || {};
@@ -270,6 +277,23 @@ const create = context => {
 				}
 
 				checkArgumentOrder({node, assertion: firstNonSkipMember, context});
+			}
+
+			if (gottenArgs === nArgs.max && nArgs.min !== nArgs.max) {
+				let lastArg = node.arguments[node.arguments.length - 1];
+
+				if (lastArg.type === 'Identifier') {
+					const variable = findVariable(context.getScope(), lastArg);
+					let value = null;
+					variable.references.forEach(ref => {
+						value = ref.writeExpr || value;
+					});
+					lastArg = value;
+				}
+
+				if (!isString(lastArg)) {
+					report(node, 'Assertion message should be a string.');
+				}
 			}
 		})
 	});

--- a/test/assertion-arguments.js
+++ b/test/assertion-arguments.js
@@ -19,6 +19,7 @@ const outOfOrderError = (line, column, endLine, endColumn) => ({
 	message: 'Expected values should come after actual values.',
 	line, column, endLine, endColumn
 });
+const messageIsNotStringError = 'Assertion message should be a string.';
 
 const header = 'const test = require(\'ava\');';
 
@@ -331,7 +332,11 @@ ruleTester.run('assertion-arguments', rule, {
 		testCase(false, 't.regex(\'static\', new RegExp(\'[dynamic]+\'));'),
 		testCase(false, 't.regex(dynamic, /[static]/);'),
 		testCase(false, 't.notRegex(\'static\', new RegExp(\'[dynamic]+\'));'),
-		testCase(false, 't.notRegex(dynamic, /[static]/);')
+		testCase(false, 't.notRegex(dynamic, /[static]/);'),
+
+		// Lookup message type
+		testCase(false, 'const message = \'ok\'; t.assert(true, message);'),
+		testCase(false, 'const message = \'ok\'; t.is(42, 42, message);')
 	],
 	invalid: [
 		// Not enough arguments
@@ -538,6 +543,12 @@ ruleTester.run('assertion-arguments', rule, {
 				outOfOrderError(1, 13, 1, 23 + expression.length),
 				{output: `t.deepEqual(${expression}, 'static');`}
 			)
-		)
+		),
+
+		// Message is not string
+		testCase(false, 't.assert(true, true);', messageIsNotStringError),
+		testCase(false, 't.deepEqual({}, {}, 42);', messageIsNotStringError),
+		testCase(false, 't.fail({});', messageIsNotStringError),
+		testCase(false, 'let message = "ok"; message = false; t.assert(true, message);', messageIsNotStringError)
 	]
 });


### PR DESCRIPTION
This will check for the presence of the extra argument (which should be the `message`) and verify if it's a string.
It will try to lookup variable and its value in the scope, but non-linear flow could break it.

```js
let message;
function woops () {
	message = null;
}
message = 'ok';
woops();
t.is('same', 'same', message); // <= this will not raise an error
```

Should we cover this ?

Fixes #167


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#167: The `assertion-arguments` rule should validate message argument type](https://issuehunt.io/repos/49722492/issues/167)
---
</details>
<!-- /Issuehunt content-->