### PR TITLE
Fix crash, false-positive in no-statement-after-end

### DIFF
--- a/test/no-statement-after-end.js
+++ b/test/no-statement-after-end.js
@@ -37,7 +37,15 @@ ruleTester.run('no-statement-after-end', rule, {
 		throw new Error();
 
 		1;
-		`
+		`,
+		cbTest(`
+			function newCodePath() {
+				throw new Error('make some unreachable code');
+				t.end();
+			}
+
+			1;
+		`)
 	],
 	invalid: [
 		{

--- a/test/no-statement-after-end.js
+++ b/test/no-statement-after-end.js
@@ -30,7 +30,14 @@ ruleTester.run('no-statement-after-end', rule, {
 		cbTest('return t.end();'),
 		cbTest('t.end(); return;'),
 		// Valid because it is not a test file (no header)
-		cbTest('t.end(); t.is(1, 1);', false)
+		cbTest('t.end(); t.is(1, 1);', false),
+		`
+		const test = require('ava');
+
+		throw new Error();
+
+		1;
+		`
 	],
 	invalid: [
 		{

--- a/test/no-statement-after-end.js
+++ b/test/no-statement-after-end.js
@@ -63,6 +63,20 @@ ruleTester.run('no-statement-after-end', rule, {
 		{
 			code: cbTest('if (t.context.a === 1) { t.end(); }\nt.is(1, 1); t.end();'),
 			errors
+		},
+		{
+			code: cbTest(`
+				function newCodePath() {
+					// ...
+				}
+				t.end();
+				1;
+			`),
+			errors
+		},
+		{
+			code: cbTest('t.end(); function newCodePath() {} 1;'),
+			errors
 		}
 	]
 });


### PR DESCRIPTION
Fixes #315 by changing the way `no-statement-after-end` records `CodePathSegment`s. The stack is used only to hold the in-progress segment in the outer `CodePath`s. When `CodePath`s begin or end, the current segment is pushed onto or popped from the stack. When `CodePathSegment`s begin or end, the current segment is set or unset.

When in unreachable code at the end of a path, the current segment is therefore undefined, rather than erroneously taken from the next-outermost path.

Checks whether the current segment is set before operating on it.

(Interestingly, this rule doesn't catch statements after `t.end()` in unreachable code, e.g.:
```javascript
throw new Error();
t.end();
1; // <-- does not trigger a report
```
This behavior predates this PR.)

While I believe this fixes the issue, I don't fully understand how this rule ought to handle its edge-cases nor why the codepath analysis system works this way. Please review carefully?