### PR TITLE
Detect more assertions in `prefer-t-regex`

### DIFF
--- a/rules/prefer-t-regex.js
+++ b/rules/prefer-t-regex.js
@@ -13,10 +13,151 @@ const create = context => {
 		'falsy'
 	]);
 
+	const equalityTests = new Set([
+		'is',
+		'deepEqual'
+	]);
+
+	// Find the latest reference to the given identifier's name.
 	const findReference = name => {
 		const reference = context.getScope().references.find(reference => reference.identifier.name === name);
+
+		if (reference === undefined) {
+			return null;
+		}
+
 		const definitions = reference.resolved.defs;
+
+		if (definitions.length === 0) {
+			return null;
+		}
+
 		return definitions[definitions.length - 1].node;
+	};
+
+	// Recursively find the "origin" node of the given node.
+	// Note: Due to some limitation, this function will only find the reference up to two layer.
+	//
+	// So the following code will only find the reference in this order: c → b → a
+	// and it will have no knowledge of the number '0'.
+	// (assuming we run this function on the identifier c)
+	// ```
+	// let a = 0;
+	// let b = a;
+	// let c = b;
+	// ```
+	const findRootReference = node => {
+		if (node.type === 'Identifier') {
+			const reference = findReference(node.name);
+
+			if (reference) {
+				return findRootReference(reference.init);
+			}
+
+			return node;
+		}
+
+		if (node.type === 'CallExpression' || node.type === 'NewExpression') {
+			return findRootReference(node.callee);
+		}
+
+		// I'm aware that there are other type of Node as well but the scope of the lint shouldn't need those.
+		return node;
+	};
+
+	// Determine if the given node is a regex expression.
+	// There are two ways to create regex expressions in JavaScript, the first being Regex Literal and the second being RegExp class.
+	// - The first way can be easily lookup using .regex field in the node.
+	// - The second way can't really be lookup so I just check the name of a class constructor/function and check if it's matches.
+	const isRegExp = lookup => {
+		if (lookup.regex) {
+			return true;
+		}
+
+		// Look up references in case it's a variable or RegExp declaration.
+		const reference = findRootReference(lookup);
+
+		if (reference) {
+			return reference.regex || reference.name === 'RegExp';
+		}
+
+		return false;
+	};
+
+	const booleanHandler = node => {
+		const firstArg = node.arguments[0];
+
+		// First argument is a call expression
+		const isFunctionCall = firstArg.type === 'CallExpression';
+		if (!isFunctionCall || !firstArg.callee.property) {
+			return;
+		}
+
+		const {name} = firstArg.callee.property;
+		let lookup = {};
+		let variable = {};
+
+		if (name === 'test') {
+			// `lookup.test(variable)`
+			lookup = firstArg.callee.object;
+			variable = firstArg.arguments[0];
+		} else if (['search', 'match'].includes(name)) {
+			// `variable.match(lookup)`
+			lookup = firstArg.arguments[0];
+			variable = firstArg.callee.object;
+		}
+
+		if (!isRegExp(lookup)) {
+			return;
+		}
+
+		const assertion = ['true', 'truthy'].includes(node.callee.property.name) ? 'regex' : 'notRegex';
+
+		const fix = fixer => {
+			const source = context.getSourceCode();
+			return [
+				fixer.replaceText(node.callee.property, assertion),
+				fixer.replaceText(firstArg, `${source.getText(variable)}, ${source.getText(lookup)}`)
+			];
+		};
+
+		context.report({
+			node,
+			message: `Prefer using the \`t.${assertion}()\` assertion.`,
+			fix
+		});
+	};
+
+	const equalityHandler = node => {
+		const [firstArg, secondArg] = node.arguments;
+
+		const firstArgumentIsRegex = isRegExp(firstArg);
+		const secondArgumentIsRegex = isRegExp(secondArg);
+
+		// If both are regex, or neither are, the expression is ok
+		if (firstArgumentIsRegex === secondArgumentIsRegex) {
+			return;
+		}
+
+		const matchee = secondArgumentIsRegex ? firstArg : secondArg;
+		const regex = secondArgumentIsRegex ? secondArg : firstArg;
+
+		const assertion = 'regex';
+
+		const fix = fixer => {
+			const source = context.getSourceCode();
+			return [
+				fixer.replaceText(node.callee.property, assertion),
+				fixer.replaceText(firstArg, `${source.getText(matchee)}`),
+				fixer.replaceText(secondArg, `${source.getText(regex)}`)
+			];
+		};
+
+		context.report({
+			node,
+			message: `Prefer using the \`t.${assertion}()\` assertion.`,
+			fix
+		});
 	};
 
 	return ava.merge({
@@ -24,64 +165,20 @@ const create = context => {
 			ava.isInTestFile,
 			ava.isInTestNode
 		])(node => {
-			// Call a boolean assertion, for example, `t.true`, `t.false`, …
-			const isBooleanAssertion = node.callee.type === 'MemberExpression' &&
-				booleanTests.has(node.callee.property.name) &&
+			const isAssertion = node.callee.type === 'MemberExpression' &&
 				util.getNameOfRootNodeObject(node.callee) === 't';
 
-			if (!isBooleanAssertion) {
-				return;
+			const isBooleanAssertion = isAssertion &&
+				booleanTests.has(node.callee.property.name);
+
+			const isEqualityAssertion = isAssertion &&
+				equalityTests.has(node.callee.property.name);
+
+			if (isBooleanAssertion) {
+				booleanHandler(node);
+			} else if (isEqualityAssertion) {
+				equalityHandler(node);
 			}
-
-			const firstArg = node.arguments[0];
-
-			// First argument is a call expression
-			const isFunctionCall = firstArg.type === 'CallExpression';
-			if (!isFunctionCall || !firstArg.callee.property) {
-				return;
-			}
-
-			const {name} = firstArg.callee.property;
-			let lookup = {};
-			let variable = {};
-
-			if (name === 'test') {
-				// `lookup.test(variable)`
-				lookup = firstArg.callee.object;
-				variable = firstArg.arguments[0];
-			} else if (['search', 'match'].includes(name)) {
-				// `variable.match(lookup)`
-				lookup = firstArg.arguments[0];
-				variable = firstArg.callee.object;
-			}
-
-			let isRegExp = lookup.regex;
-
-			// It's not a regexp but an identifier
-			if (!isRegExp && lookup.type === 'Identifier') {
-				const reference = findReference(lookup.name);
-				isRegExp = reference.init.regex;
-			}
-
-			if (!isRegExp) {
-				return;
-			}
-
-			const assertion = ['true', 'truthy'].includes(node.callee.property.name) ? 'regex' : 'notRegex';
-
-			const fix = fixer => {
-				const source = context.getSourceCode();
-				return [
-					fixer.replaceText(node.callee.property, assertion),
-					fixer.replaceText(firstArg, `${source.getText(variable)}, ${source.getText(lookup)}`)
-				];
-			};
-
-			context.report({
-				node,
-				message: `Prefer using the \`t.${assertion}()\` assertion.`,
-				fix
-			});
 		})
 	});
 };

--- a/rules/prefer-t-regex.js
+++ b/rules/prefer-t-regex.js
@@ -81,10 +81,7 @@ const create = context => {
 
 		// Look up references in case it's a variable or RegExp declaration.
 		const reference = findRootReference(lookup);
-
-		if (reference) {
-			return reference.regex || reference.name === 'RegExp';
-		}
+		return reference.regex || reference.name === 'RegExp';
 	};
 
 	const booleanHandler = node => {

--- a/rules/prefer-t-regex.js
+++ b/rules/prefer-t-regex.js
@@ -33,21 +33,22 @@ const create = context => {
 		}
 	};
 
-	// Recursively find the "origin" node of the given node.
-	// Note:
-	//    context.getScope() doesn't contain information about
-	// the outer scope so in most case this function will only
-	// find the reference directly above the current scope.
-	//
-	// So the following code will only find the reference in this order: y -> x
-	// and it will have no knowledge of the number '0'.
-	// (assuming we run this function on the identifier y)
-	// ```
-	// const test = require('ava');
-	// let x = 0;
-	// let y = x;
-	// test(t => t.is(y, 0));
-	// ```
+	/*
+	Recursively find the "origin" node of the given node.
+
+	Note: `context.getScope()` doesn't contain information about the outer scope so in most cases this function will only find the reference directly above the current scope. So the following code will only find the reference in this order: y -> x, and it will have no knowledge of the number `0`. (assuming we run this function on the identifier `y`)
+
+	```
+	const test = require('ava');
+
+	let x = 0;
+	let y = x;
+
+	test(t => {
+		t.is(y, 0);
+	});
+	```
+	*/
 	const findRootReference = node => {
 		if (node.type === 'Identifier') {
 			const reference = findReference(node.name);
@@ -70,10 +71,13 @@ const create = context => {
 		return node;
 	};
 
-	// Determine if the given node is a regex expression.
-	// There are two ways to create regex expressions in JavaScript: Regex Literal and RegExp class.
-	//  1. Regex Literal can be easily lookup using .regex field in the node.
-	//  2. RegExp class can't be lookup so the function just checks for the name 'RegExp'.
+	/*
+	Determine if the given node is a regex expression.
+
+	There are two ways to create regex expressions in JavaScript: Regex literal and `RegExp` class.
+	1. Regex literal can be easily looked up using the `.regex` property on the node.
+	2. `RegExp` class can't be looked up so the function just checks for the name `RegExp`.
+	*/
 	const isRegExp = lookup => {
 		if (lookup.regex) {
 			return true;
@@ -133,7 +137,7 @@ const create = context => {
 		const firstArgumentIsRegex = isRegExp(firstArg);
 		const secondArgumentIsRegex = isRegExp(secondArg);
 
-		// If both are regex, or neither are, the expression is ok
+		// If both are regex, or neither are, the expression is ok.
 		if (firstArgumentIsRegex === secondArgumentIsRegex) {
 			return;
 		}
@@ -150,7 +154,7 @@ const create = context => {
 			];
 		};
 
-		// Only fix a statically verifiable equality
+		// Only fix a statically verifiable equality.
 		if (regex && matchee.type === 'Literal') {
 			let assertion;
 

--- a/rules/prefer-t-regex.js
+++ b/rules/prefer-t-regex.js
@@ -26,7 +26,7 @@ const create = context => {
 			const definitions = reference.resolved.defs;
 
 			if (definitions.length === 0) {
-				return null;
+				return;
 			}
 
 			return definitions[definitions.length - 1].node;

--- a/rules/prefer-t-regex.js
+++ b/rules/prefer-t-regex.js
@@ -22,17 +22,15 @@ const create = context => {
 	const findReference = name => {
 		const reference = context.getScope().references.find(reference => reference.identifier.name === name);
 
-		if (reference === undefined) {
-			return null;
+		if (reference && reference.resolved) {
+			const definitions = reference.resolved.defs;
+
+			if (definitions.length === 0) {
+				return null;
+			}
+
+			return definitions[definitions.length - 1].node;
 		}
-
-		const definitions = reference.resolved.defs;
-
-		if (definitions.length === 0) {
-			return null;
-		}
-
-		return definitions[definitions.length - 1].node;
 	};
 
 	// Recursively find the "origin" node of the given node.
@@ -50,7 +48,7 @@ const create = context => {
 		if (node.type === 'Identifier') {
 			const reference = findReference(node.name);
 
-			if (reference) {
+			if (reference && reference.init) {
 				return findRootReference(reference.init);
 			}
 

--- a/test/prefer-t-regex.js
+++ b/test/prefer-t-regex.js
@@ -17,14 +17,21 @@ ruleTester.run('prefer-t-regex', rule, {
 	valid: [
 		header + 'test(t => t.regex("foo", /\\d+/));',
 		header + 'test(t => t.regex(foo(), /\\d+/));',
-		header + 'test(t => t.is(/\\d+/.test("foo"), true));',
+		header + 'test(t => t.is(/\\d+/.test("foo"), foo));',
+		header + 'test(t => t.is(RegExp("\\d+").test("foo"), foo));',
+		header + 'test(t => t.is(RegExp(/\\d+/).test("foo"), foo));',
+		header + 'test(t => t.is(/\\d+/, /\\w+/));',
+		header + 'test(t => t.is(123, /\\d+/));',
 		header + 'test(t => t.true(1 === 1));',
 		header + 'test(t => t.true(foo.bar()));',
+		header + 'test(t => t.is(foo, true));',
 		header + 'const a = /\\d+/;\ntest(t => t.truthy(a));',
 		header + 'const a = "not a regexp";\ntest(t => t.true(a.test("foo")));',
 		header + 'test("main", t => t.true(foo()));',
 		header + 'test(t => t.regex(foo, new RegExp("\\d+")));',
 		header + 'test(t => t.regex(foo, RegExp("\\d+")));',
+		header + 'test(t => t.regex(foo, new RegExp(/\\d+/)));',
+		header + 'test(t => t.regex(foo, RegExp(/\\d+/)));',
 		// Shouldn't be triggered since it's not a test file
 		'test(t => t.true(/\\d+/.test("foo")));'
 	],
@@ -58,6 +65,16 @@ ruleTester.run('prefer-t-regex', rule, {
 			code: header + 'test(t => t.true(/\\d+/.test(foo())));',
 			output: header + 'test(t => t.regex(foo(), /\\d+/));',
 			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.is(/\\d+/.test(foo), true));',
+			output: header + 'test(t => t.regex(foo, /\\d+/));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.is(/\\d+/.test(foo), false));',
+			output: header + 'test(t => t.notRegex(foo, /\\d+/));',
+			errors: errors('notRegex')
 		},
 		{
 			code: header + 'const reg = /\\d+/;\ntest(t => t.true(reg.test(foo.bar())));',
@@ -96,8 +113,64 @@ ruleTester.run('prefer-t-regex', rule, {
 			errors: errors('regex')
 		},
 		{
+			code: header + 'test(t => t.is(new RegExp("\\d+").test(foo), true));',
+			output: header + 'test(t => t.regex(foo, new RegExp("\\d+")));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.is(new RegExp("\\d+").test(foo), false));',
+			output: header + 'test(t => t.notRegex(foo, new RegExp("\\d+")));',
+			errors: errors('notRegex')
+		},
+		{
 			code: header + 'const reg = RegExp("\\d+");\ntest(t => t.true(reg.test(foo.bar())));',
 			output: header + 'const reg = RegExp("\\d+");\ntest(t => t.regex(foo.bar(), reg));',
+			errors: errors('regex')
+		},
+		// The same as the above tests but with regex literal instead of string regex
+		{
+			code: header + 'test(t => t.true(new RegExp(/\\d+/).test("foo")));',
+			output: header + 'test(t => t.regex("foo", new RegExp(/\\d+/)));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.false(foo.search(new RegExp(/\\d+/))));',
+			output: header + 'test(t => t.notRegex(foo, new RegExp(/\\d+/)));',
+			errors: errors('notRegex')
+		},
+		{
+			code: header + 'const regexp = RegExp(/\\d+/);\ntest(t => t.true(foo.search(regexp)));',
+			output: header + 'const regexp = RegExp(/\\d+/);\ntest(t => t.regex(foo, regexp));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.truthy(foo.match(new RegExp(/\\d+/))));',
+			output: header + 'test(t => t.regex(foo, new RegExp(/\\d+/)));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.false(RegExp(/\\d+/).test("foo")));',
+			output: header + 'test(t => t.notRegex("foo", RegExp(/\\d+/)));',
+			errors: errors('notRegex')
+		},
+		{
+			code: header + 'test(t => t.true(new RegExp(/\\d+/).test(foo())));',
+			output: header + 'test(t => t.regex(foo(), new RegExp(/\\d+/)));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.is(new RegExp(/\\d+/).test(foo), true));',
+			output: header + 'test(t => t.regex(foo, new RegExp(/\\d+/)));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.is(new RegExp(/\\d+/).test(foo), false));',
+			output: header + 'test(t => t.notRegex(foo, new RegExp(/\\d+/)));',
+			errors: errors('notRegex')
+		},
+		{
+			code: header + 'const reg = RegExp(/\\d+/);\ntest(t => t.true(reg.test(foo.bar())));',
+			output: header + 'const reg = RegExp(/\\d+/);\ntest(t => t.regex(foo.bar(), reg));',
 			errors: errors('regex')
 		}
 	]

--- a/test/prefer-t-regex.js
+++ b/test/prefer-t-regex.js
@@ -17,12 +17,14 @@ ruleTester.run('prefer-t-regex', rule, {
 	valid: [
 		header + 'test(t => t.regex("foo", /\\d+/));',
 		header + 'test(t => t.regex(foo(), /\\d+/));',
-		header + 'test(t => t.is(/\\d+/.test("foo")), true);',
+		header + 'test(t => t.is(/\\d+/.test("foo"), true));',
 		header + 'test(t => t.true(1 === 1));',
 		header + 'test(t => t.true(foo.bar()));',
 		header + 'const a = /\\d+/;\ntest(t => t.truthy(a));',
 		header + 'const a = "not a regexp";\ntest(t => t.true(a.test("foo")));',
 		header + 'test("main", t => t.true(foo()));',
+		header + 'test(t => t.regex(foo, new RegExp("\\d+")));',
+		header + 'test(t => t.regex(foo, RegExp("\\d+")));',
 		// Shouldn't be triggered since it's not a test file
 		'test(t => t.true(/\\d+/.test("foo")));'
 	],
@@ -60,6 +62,42 @@ ruleTester.run('prefer-t-regex', rule, {
 		{
 			code: header + 'const reg = /\\d+/;\ntest(t => t.true(reg.test(foo.bar())));',
 			output: header + 'const reg = /\\d+/;\ntest(t => t.regex(foo.bar(), reg));',
+			errors: errors('regex')
+		},
+		// The same as the above tests but with `RegExp()` object instead of a regex literal
+		{
+			code: header + 'test(t => t.true(new RegExp("\\d+").test("foo")));',
+			output: header + 'test(t => t.regex("foo", new RegExp("\\d+")));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.false(foo.search(new RegExp("\\d+"))));',
+			output: header + 'test(t => t.notRegex(foo, new RegExp("\\d+")));',
+			errors: errors('notRegex')
+		},
+		{
+			code: header + 'const regexp = RegExp("\\d+");\ntest(t => t.true(foo.search(regexp)));',
+			output: header + 'const regexp = RegExp("\\d+");\ntest(t => t.regex(foo, regexp));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.truthy(foo.match(new RegExp("\\d+"))));',
+			output: header + 'test(t => t.regex(foo, new RegExp("\\d+")));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'test(t => t.false(RegExp("\\d+").test("foo")));',
+			output: header + 'test(t => t.notRegex("foo", RegExp("\\d+")));',
+			errors: errors('notRegex')
+		},
+		{
+			code: header + 'test(t => t.true(new RegExp("\\d+").test(foo())));',
+			output: header + 'test(t => t.regex(foo(), new RegExp("\\d+")));',
+			errors: errors('regex')
+		},
+		{
+			code: header + 'const reg = RegExp("\\d+");\ntest(t => t.true(reg.test(foo.bar())));',
+			output: header + 'const reg = RegExp("\\d+");\ntest(t => t.regex(foo.bar(), reg));',
 			errors: errors('regex')
 		}
 	]


### PR DESCRIPTION
This pull request is a continuation from #297 work and fixes #275 

I've added support for `RegExp()` as requested in the previous PR as well as the necessary tests. 🦄


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#275: Detect more assertions in the `t-prefer-regex` rule](https://issuehunt.io/repos/49722492/issues/275)
---
</details>
<!-- /Issuehunt content-->