### PR TITLE
Fix small typo in rule report message of no-todo-test

### DIFF
--- a/rules/no-todo-test.js
+++ b/rules/no-todo-test.js
@@ -14,7 +14,7 @@ const create = context => {
 			if (ava.hasTestModifier('todo')) {
 				context.report({
 					node,
-					message: '`test.todo()` should be not be used.'
+					message: '`test.todo()` should not be used.'
 				});
 			}
 		})


### PR DESCRIPTION
I just noticed that there's an extra "be" in the message the rule `no-todo-test` reports.