### PR TITLE
Add an option to avoid fixing no-skip-test

### DIFF
--- a/docs/rules/no-skip-test.md
+++ b/docs/rules/no-skip-test.md
@@ -35,3 +35,15 @@ test('bar', t => {
 	t.pass();
 });
 ```
+
+## Options
+
+The rule takes the following options:
+
+* `fix`: whether to fix violations (default true)
+
+You can set the option in configuration like this:
+
+```js
+"ava/no-skip-test": ["error", { fix: false }]
+```

--- a/rules/no-skip-test.js
+++ b/rules/no-skip-test.js
@@ -4,6 +4,8 @@ const createAvaRule = require('../create-ava-rule');
 const util = require('../util');
 
 const create = context => {
+	const [options] = context.options;
+	const {fix = true} = (options || {});
 	const ava = createAvaRule();
 
 	return ava.merge({
@@ -16,18 +18,30 @@ const create = context => {
 				context.report({
 					node: propertyNode,
 					message: 'No tests should be skipped.',
-					fix: fixer => {
-						return fixer.replaceTextRange.apply(null, util.removeTestModifier({
-							modifier: 'skip',
-							node,
-							context
-						}));
-					}
+					...(fix && {
+						fix: fixer => {
+							return fixer.replaceTextRange.apply(null, util.removeTestModifier({
+								modifier: 'skip',
+								node,
+								context
+							}));
+						}
+					})
 				});
 			}
 		})
 	});
 };
+
+const schema = [{
+	type: 'object',
+	properties: {
+		fix: {
+			type: 'boolean',
+			default: true
+		}
+	}
+}];
 
 module.exports = {
 	create,
@@ -36,6 +50,7 @@ module.exports = {
 			url: util.getDocsUrl(__filename)
 		},
 		fixable: 'code',
-		type: 'suggestion'
+		type: 'suggestion',
+		schema
 	}
 };

--- a/test/no-skip-test.js
+++ b/test/no-skip-test.js
@@ -33,6 +33,19 @@ ruleTester.run('no-skip-test', rule, {
 			}]
 		},
 		{
+			code: header + 'test.skip(t => { t.pass(); });',
+			output: header + 'test.skip(t => { t.pass(); });',
+			options: [{
+				fix: false
+			}],
+			errors: [{
+				message,
+				type: 'Identifier',
+				line: 2,
+				column: 6
+			}]
+		},
+		{
 			code: header + 'test.cb.skip(t => { t.pass(); t.end(); });',
 			output: header + 'test.cb(t => { t.pass(); t.end(); });',
 			errors: [{


### PR DESCRIPTION
My team's projects run `eslint --fix` by deafult, and some of our editors apply lint-fixes on save by default.

This has led to some issues with this rule (with I 100% wish to keep using):
* People adding `// eslint-disable-next-line ava/no-skip-test` to get around their editors' auto-fix, then accidentally committing the whole file without fixing it
* Adding this rule to an existing project can strip `test.skip()` in a bunch of places that deserve manual inspection

This option also lets projects opt-in to working like the [eslint docs recommend](https://eslint.org/docs/developer-guide/working-with-rules#applying-fixes):

> Best practices for fixes:
>
> 1. Avoid any fixes that could change the runtime behavior of code and cause it to stop working.

If this is accepted, I'd like to do the same thing for `no-only-test` for the same reasons.