### PR TITLE
Add failing test for `prefer-t-regex`

### DIFF
--- a/test/prefer-t-regex.js
+++ b/test/prefer-t-regex.js
@@ -34,6 +34,8 @@ ruleTester.run('prefer-t-regex', rule, {
 		header + 'test(t => t.regex(foo, RegExp(/\\d+/)));',
 		// Shouldn't be triggered since it's not a test file
 		'test(t => t.true(/\\d+/.test("foo")));',
+		// Not valid, but it shouldn't cause errors
+		'test(t => t.true());',
 	],
 	invalid: [
 		{


### PR DESCRIPTION
As mentioned in https://github.com/avajs/eslint-plugin-ava/issues/317#issuecomment-922262370

> 
> 
> https://github.com/fregante/chrome-webstore-upload-cli/blob/ab45edaf6b1681c9ce50caf65acfa89ed6f66714/test/cli.js#L27
> 
> ```
> TypeError: Cannot read property 'type' of undefined
> Occurred while linting ./test/cli.js:22
>     at booleanHandler (./node_modules/eslint-plugin-ava/rules/prefer-t-regex.js:94:35)
>     at ./node_modules/eslint-plugin-ava/rules/prefer-t-regex.js:192:5
>     at ./node_modules/enhance-visitors/index.js:25:12
>     at ./node_modules/enhance-visitors/index.js:15:7
>     at ./node_modules/eslint/lib/linter/safe-emitter.js:45:58
>     at Array.forEach (<anonymous>)
>     at Object.emit (./node_modules/eslint/lib/linter/safe-emitter.js:45:38)
>     at NodeEventGenerator.applySelector (./node_modules/eslint/lib/linter/node-event-generator.js:293:26)
>     at NodeEventGenerator.applySelectors (./node_modules/eslint/lib/linter/node-event-generator.js:322:22)
>     at NodeEventGenerator.enterNode (./node_modules/eslint/lib/linter/node-event-generator.js:336:14)
> ```
> 
> 
> I had seen this error before but it wasn't clear what the issue was since the line does not match the error (and there's no "type" in the user code)