### PR TITLE
`use-test`: Ignore type import

### DIFF
--- a/docs/rules/use-test.md
+++ b/docs/rules/use-test.md
@@ -3,7 +3,7 @@
 Translations: [Français](https://github.com/avajs/ava-docs/blob/main/fr_FR/related/eslint-plugin-ava/docs/rules/use-test.md)
 
 The convention is to import AVA and assign it to a variable named `test`. Most rules in `eslint-plugin-ava` are based on that assumption.
-In a TypeScript file (`.ts` or `.tsx`) AVA can be assigned to a variable named `anyTest` in order to define the types of `t.context` (see [Typing t.context](https://github.com/avajs/ava/blob/main/docs/recipes/typescript.md#typing-tcontext)).
+In a TypeScript file (`.ts` or `.tsx`) AVA can be assigned to a variable named `anyTest` in order to define the types of `t.context` (see [Typing t.context](https://github.com/avajs/ava/blob/main/docs/recipes/typescript.md#typing-tcontext)). Type-only imports (`import type ... from 'ava'`) are not linted.
 
 ### Fail
 
@@ -28,6 +28,7 @@ const test = require('foo');
 
 ```ts
 import anyTest from 'ava';
+import type { TestInterface } from 'ava';
 
 const test = anyTest as TestInterface<{foo: string}>;
 ```

--- a/docs/rules/use-test.md
+++ b/docs/rules/use-test.md
@@ -28,7 +28,7 @@ const test = require('foo');
 
 ```ts
 import anyTest from 'ava';
-import type { TestInterface } from 'ava';
+import type {TestInterface} from 'ava';
 
 const test = anyTest as TestInterface<{foo: string}>;
 ```

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"resolve-from": "^5.0.0"
 	},
 	"devDependencies": {
+		"@typescript-eslint/parser": "^5.9.0",
 		"ava": "^3.15.0",
 		"c8": "^7.7.3",
 		"chalk": "^4.1.1",

--- a/rules/use-test.js
+++ b/rules/use-test.js
@@ -31,7 +31,7 @@ const create = context => {
 	const isTypeScript = ext === '.ts' || ext === '.tsx';
 
 	return {
-		ImportDeclaration: node => {
+		'ImportDeclaration[importKind!="type"]': node => {
 			if (node.source.value === 'ava') {
 				const {name} = node.specifiers[0].local;
 				if (name !== 'test' && (!isTypeScript || name !== 'anyTest')) {

--- a/test/use-test.js
+++ b/test/use-test.js
@@ -13,9 +13,13 @@ const ruleTester = avaRuleTester(test, {
 	},
 });
 
+const typescriptRuleTester = avaRuleTester(test, {
+	parser: require.resolve('@typescript-eslint/parser'),
+});
+
 const errors = [{}];
 
-ruleTester.run('use-test', rule, {
+const commonTestCases = {
 	valid: [
 		{code: 'var test = require(\'ava\');', filename: 'file.js'},
 		{code: 'let test = require(\'ava\');', filename: 'file.js'},
@@ -124,4 +128,16 @@ ruleTester.run('use-test', rule, {
 			filename: 'file.tsx',
 		},
 	],
-});
+};
+
+const typescriptTestCases = {
+	valid: [
+		{code: 'import type { Macro } from \'ava\';', filename: 'file.ts'},
+		{code: 'import type { Macro } from \'ava\';', filename: 'file.tsx'},
+	],
+	invalid: [],
+};
+
+ruleTester.run('use-test', rule, commonTestCases);
+typescriptRuleTester.run('use-test', rule, commonTestCases);
+typescriptRuleTester.run('use-test', rule, typescriptTestCases);

--- a/test/use-test.js
+++ b/test/use-test.js
@@ -132,8 +132,8 @@ const commonTestCases = {
 
 const typescriptTestCases = {
 	valid: [
-		{code: 'import type { Macro } from \'ava\';', filename: 'file.ts'},
-		{code: 'import type { Macro } from \'ava\';', filename: 'file.tsx'},
+		{code: 'import type {Macro} from \'ava\';', filename: 'file.ts'},
+		{code: 'import type {Macro} from \'ava\';', filename: 'file.tsx'},
 	],
 	invalid: [],
 };


### PR DESCRIPTION
This fixes #320 by ignoring type-only imports (like `import type { Macro } from 'ava';`).