### PR TITLE
Update to eslint-doc-generator v1.0.0

### DIFF
--- a/docs/rules/assertion-arguments.md
+++ b/docs/rules/assertion-arguments.md
@@ -1,6 +1,6 @@
 # Enforce passing correct arguments to assertions (`ava/assertion-arguments`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/hooks-order.md
+++ b/docs/rules/hooks-order.md
@@ -1,6 +1,6 @@
 # Enforce test hook ordering (`ava/hooks-order`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/max-asserts.md
+++ b/docs/rules/max-asserts.md
@@ -1,6 +1,6 @@
 # Enforce a limit on the number of assertions in a test (`ava/max-asserts`)
 
-✅ This rule is _disabled_ in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-async-fn-without-await.md
+++ b/docs/rules/no-async-fn-without-await.md
@@ -1,6 +1,6 @@
 # Ensure that async tests use `await` (`ava/no-async-fn-without-await`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-duplicate-modifiers.md
+++ b/docs/rules/no-duplicate-modifiers.md
@@ -1,6 +1,6 @@
 # Ensure tests do not have duplicate modifiers (`ava/no-duplicate-modifiers`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-identical-title.md
+++ b/docs/rules/no-identical-title.md
@@ -1,6 +1,6 @@
 # Ensure no tests have the same title (`ava/no-identical-title`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-ignored-test-files.md
+++ b/docs/rules/no-ignored-test-files.md
@@ -1,6 +1,6 @@
 # Ensure no tests are written in ignored files (`ava/no-ignored-test-files`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-import-test-files.md
+++ b/docs/rules/no-import-test-files.md
@@ -1,6 +1,6 @@
 # Ensure no test files are imported anywhere (`ava/no-import-test-files`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-incorrect-deep-equal.md
+++ b/docs/rules/no-incorrect-deep-equal.md
@@ -1,6 +1,6 @@
 # Disallow using `deepEqual` with primitives (`ava/no-incorrect-deep-equal`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-inline-assertions.md
+++ b/docs/rules/no-inline-assertions.md
@@ -1,6 +1,6 @@
 # Ensure assertions are not called from inline arrow functions (`ava/no-inline-assertions`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-nested-tests.md
+++ b/docs/rules/no-nested-tests.md
@@ -1,6 +1,6 @@
 # Ensure no tests are nested (`ava/no-nested-tests`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-only-test.md
+++ b/docs/rules/no-only-test.md
@@ -1,6 +1,6 @@
 # Ensure no `test.only()` are present (`ava/no-only-test`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 🔧💡 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/docs/rules/no-skip-assert.md
+++ b/docs/rules/no-skip-assert.md
@@ -1,6 +1,6 @@
 # Ensure no assertions are skipped (`ava/no-skip-assert`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-skip-test.md
+++ b/docs/rules/no-skip-test.md
@@ -1,6 +1,6 @@
 # Ensure no tests are skipped (`ava/no-skip-test`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 🔧💡 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/docs/rules/no-todo-implementation.md
+++ b/docs/rules/no-todo-implementation.md
@@ -1,6 +1,6 @@
 # Ensure `test.todo()` is not given an implementation function (`ava/no-todo-implementation`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-todo-test.md
+++ b/docs/rules/no-todo-test.md
@@ -1,6 +1,6 @@
 # Ensure no `test.todo()` is used (`ava/no-todo-test`)
 
-✅ This rule will _warn_ in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+⚠️ This rule _warns_ in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-unknown-modifiers.md
+++ b/docs/rules/no-unknown-modifiers.md
@@ -1,6 +1,6 @@
 # Disallow the use of unknown test modifiers (`ava/no-unknown-modifiers`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/prefer-async-await.md
+++ b/docs/rules/prefer-async-await.md
@@ -1,6 +1,6 @@
 # Prefer using async/await instead of returning a Promise (`ava/prefer-async-await`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/prefer-power-assert.md
+++ b/docs/rules/prefer-power-assert.md
@@ -1,6 +1,6 @@
 # Enforce the use of the asserts that have no [power-assert](https://github.com/power-assert-js/power-assert) alternative (`ava/prefer-power-assert`)
 
-✅ This rule is _disabled_ in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/prefer-t-regex.md
+++ b/docs/rules/prefer-t-regex.md
@@ -1,6 +1,6 @@
 # Prefer using `t.regex()` to test regular expressions (`ava/prefer-t-regex`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/test-title-format.md
+++ b/docs/rules/test-title-format.md
@@ -1,6 +1,6 @@
 # Ensure test titles have a certain format (`ava/test-title-format`)
 
-✅ This rule is _disabled_ in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/test-title.md
+++ b/docs/rules/test-title.md
@@ -1,6 +1,6 @@
 # Ensure tests have a title (`ava/test-title`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/use-t-throws-async-well.md
+++ b/docs/rules/use-t-throws-async-well.md
@@ -1,6 +1,6 @@
 # Ensure that `t.throwsAsync()` and `t.notThrowsAsync()` are awaited (`ava/use-t-throws-async-well`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/use-t-well.md
+++ b/docs/rules/use-t-well.md
@@ -1,6 +1,6 @@
 # Disallow the incorrect use of `t` (`ava/use-t-well`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/use-t.md
+++ b/docs/rules/use-t.md
@@ -1,6 +1,6 @@
 # Ensure test functions use `t` as their parameter (`ava/use-t`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/use-test.md
+++ b/docs/rules/use-test.md
@@ -1,6 +1,6 @@
 # Ensure that AVA is imported with `test` as the variable name (`ava/use-test`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/use-true-false.md
+++ b/docs/rules/use-true-false.md
@@ -1,6 +1,6 @@
 # Ensure that `t.true()`/`t.false()` are used instead of `t.truthy()`/`t.falsy()` (`ava/use-true-false`)
 
-✅ This rule is enabled in the `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 
 <!-- end auto-generated rule header -->
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"del": "^6.0.0",
 		"eslint": "^8.26.0",
 		"eslint-ava-rule-tester": "^4.0.0",
-		"eslint-doc-generator": "^0.16.0",
+		"eslint-doc-generator": "^1.0.0",
 		"eslint-plugin-eslint-plugin": "^5.0.6",
 		"execa": "^5.1.1",
 		"listr": "^0.14.3",

--- a/readme.md
+++ b/readme.md
@@ -46,39 +46,42 @@ The rules will only activate in test files.
 
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the `recommended` [configuration](https://github.com/avajs/eslint-plugin-ava#recommended-config).\
+💼 [Configurations](https://github.com/avajs/eslint-plugin-ava#recommended-config) enabled in.\
+⚠️ [Configurations](https://github.com/avajs/eslint-plugin-ava#recommended-config) set to warn in.\
+🚫 [Configurations](https://github.com/avajs/eslint-plugin-ava#recommended-config) disabled in.\
+✅ Set in the `recommended` [configuration](https://github.com/avajs/eslint-plugin-ava#recommended-config).\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Name                                                                 | Description                                                                                                              | ✅  | 🔧  | 💡  |
-| :------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- | :-- | :-- | :-- |
-| [assertion-arguments](docs/rules/assertion-arguments.md)             | Enforce passing correct arguments to assertions.                                                                         | ✅  | 🔧  |     |
-| [hooks-order](docs/rules/hooks-order.md)                             | Enforce test hook ordering.                                                                                              | ✅  | 🔧  |     |
-| [max-asserts](docs/rules/max-asserts.md)                             | Enforce a limit on the number of assertions in a test.                                                                   |     |     |     |
-| [no-async-fn-without-await](docs/rules/no-async-fn-without-await.md) | Ensure that async tests use `await`.                                                                                     | ✅  |     |     |
-| [no-duplicate-modifiers](docs/rules/no-duplicate-modifiers.md)       | Ensure tests do not have duplicate modifiers.                                                                            | ✅  |     |     |
-| [no-identical-title](docs/rules/no-identical-title.md)               | Ensure no tests have the same title.                                                                                     | ✅  |     |     |
-| [no-ignored-test-files](docs/rules/no-ignored-test-files.md)         | Ensure no tests are written in ignored files.                                                                            | ✅  |     |     |
-| [no-import-test-files](docs/rules/no-import-test-files.md)           | Ensure no test files are imported anywhere.                                                                              | ✅  |     |     |
-| [no-incorrect-deep-equal](docs/rules/no-incorrect-deep-equal.md)     | Disallow using `deepEqual` with primitives.                                                                              | ✅  | 🔧  |     |
-| [no-inline-assertions](docs/rules/no-inline-assertions.md)           | Ensure assertions are not called from inline arrow functions.                                                            | ✅  | 🔧  |     |
-| [no-nested-tests](docs/rules/no-nested-tests.md)                     | Ensure no tests are nested.                                                                                              | ✅  |     |     |
-| [no-only-test](docs/rules/no-only-test.md)                           | Ensure no `test.only()` are present.                                                                                     | ✅  | 🔧  | 💡  |
-| [no-skip-assert](docs/rules/no-skip-assert.md)                       | Ensure no assertions are skipped.                                                                                        | ✅  |     |     |
-| [no-skip-test](docs/rules/no-skip-test.md)                           | Ensure no tests are skipped.                                                                                             | ✅  | 🔧  | 💡  |
-| [no-todo-implementation](docs/rules/no-todo-implementation.md)       | Ensure `test.todo()` is not given an implementation function.                                                            | ✅  |     |     |
-| [no-todo-test](docs/rules/no-todo-test.md)                           | Ensure no `test.todo()` is used.                                                                                         |     |     |     |
-| [no-unknown-modifiers](docs/rules/no-unknown-modifiers.md)           | Disallow the use of unknown test modifiers.                                                                              | ✅  |     |     |
-| [prefer-async-await](docs/rules/prefer-async-await.md)               | Prefer using async/await instead of returning a Promise.                                                                 | ✅  |     |     |
-| [prefer-power-assert](docs/rules/prefer-power-assert.md)             | Enforce the use of the asserts that have no [power-assert](https://github.com/power-assert-js/power-assert) alternative. |     |     |     |
-| [prefer-t-regex](docs/rules/prefer-t-regex.md)                       | Prefer using `t.regex()` to test regular expressions.                                                                    | ✅  | 🔧  |     |
-| [test-title](docs/rules/test-title.md)                               | Ensure tests have a title.                                                                                               | ✅  |     |     |
-| [test-title-format](docs/rules/test-title-format.md)                 | Ensure test titles have a certain format.                                                                                |     |     |     |
-| [use-t](docs/rules/use-t.md)                                         | Ensure test functions use `t` as their parameter.                                                                        | ✅  |     |     |
-| [use-t-throws-async-well](docs/rules/use-t-throws-async-well.md)     | Ensure that `t.throwsAsync()` and `t.notThrowsAsync()` are awaited.                                                      | ✅  | 🔧  |     |
-| [use-t-well](docs/rules/use-t-well.md)                               | Disallow the incorrect use of `t`.                                                                                       | ✅  | 🔧  |     |
-| [use-test](docs/rules/use-test.md)                                   | Ensure that AVA is imported with `test` as the variable name.                                                            | ✅  |     |     |
-| [use-true-false](docs/rules/use-true-false.md)                       | Ensure that `t.true()`/`t.false()` are used instead of `t.truthy()`/`t.falsy()`.                                         | ✅  |     |     |
+| Name                                                                 | Description                                                                                                              | 💼 | ⚠️ | 🚫 | 🔧 | 💡 |
+| :------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- | :- | :- | :- | :- | :- |
+| [assertion-arguments](docs/rules/assertion-arguments.md)             | Enforce passing correct arguments to assertions.                                                                         | ✅  |    |    | 🔧 |    |
+| [hooks-order](docs/rules/hooks-order.md)                             | Enforce test hook ordering.                                                                                              | ✅  |    |    | 🔧 |    |
+| [max-asserts](docs/rules/max-asserts.md)                             | Enforce a limit on the number of assertions in a test.                                                                   |    |    | ✅  |    |    |
+| [no-async-fn-without-await](docs/rules/no-async-fn-without-await.md) | Ensure that async tests use `await`.                                                                                     | ✅  |    |    |    |    |
+| [no-duplicate-modifiers](docs/rules/no-duplicate-modifiers.md)       | Ensure tests do not have duplicate modifiers.                                                                            | ✅  |    |    |    |    |
+| [no-identical-title](docs/rules/no-identical-title.md)               | Ensure no tests have the same title.                                                                                     | ✅  |    |    |    |    |
+| [no-ignored-test-files](docs/rules/no-ignored-test-files.md)         | Ensure no tests are written in ignored files.                                                                            | ✅  |    |    |    |    |
+| [no-import-test-files](docs/rules/no-import-test-files.md)           | Ensure no test files are imported anywhere.                                                                              | ✅  |    |    |    |    |
+| [no-incorrect-deep-equal](docs/rules/no-incorrect-deep-equal.md)     | Disallow using `deepEqual` with primitives.                                                                              | ✅  |    |    | 🔧 |    |
+| [no-inline-assertions](docs/rules/no-inline-assertions.md)           | Ensure assertions are not called from inline arrow functions.                                                            | ✅  |    |    | 🔧 |    |
+| [no-nested-tests](docs/rules/no-nested-tests.md)                     | Ensure no tests are nested.                                                                                              | ✅  |    |    |    |    |
+| [no-only-test](docs/rules/no-only-test.md)                           | Ensure no `test.only()` are present.                                                                                     | ✅  |    |    | 🔧 | 💡 |
+| [no-skip-assert](docs/rules/no-skip-assert.md)                       | Ensure no assertions are skipped.                                                                                        | ✅  |    |    |    |    |
+| [no-skip-test](docs/rules/no-skip-test.md)                           | Ensure no tests are skipped.                                                                                             | ✅  |    |    | 🔧 | 💡 |
+| [no-todo-implementation](docs/rules/no-todo-implementation.md)       | Ensure `test.todo()` is not given an implementation function.                                                            | ✅  |    |    |    |    |
+| [no-todo-test](docs/rules/no-todo-test.md)                           | Ensure no `test.todo()` is used.                                                                                         |    | ✅  |    |    |    |
+| [no-unknown-modifiers](docs/rules/no-unknown-modifiers.md)           | Disallow the use of unknown test modifiers.                                                                              | ✅  |    |    |    |    |
+| [prefer-async-await](docs/rules/prefer-async-await.md)               | Prefer using async/await instead of returning a Promise.                                                                 | ✅  |    |    |    |    |
+| [prefer-power-assert](docs/rules/prefer-power-assert.md)             | Enforce the use of the asserts that have no [power-assert](https://github.com/power-assert-js/power-assert) alternative. |    |    | ✅  |    |    |
+| [prefer-t-regex](docs/rules/prefer-t-regex.md)                       | Prefer using `t.regex()` to test regular expressions.                                                                    | ✅  |    |    | 🔧 |    |
+| [test-title](docs/rules/test-title.md)                               | Ensure tests have a title.                                                                                               | ✅  |    |    |    |    |
+| [test-title-format](docs/rules/test-title-format.md)                 | Ensure test titles have a certain format.                                                                                |    |    | ✅  |    |    |
+| [use-t](docs/rules/use-t.md)                                         | Ensure test functions use `t` as their parameter.                                                                        | ✅  |    |    |    |    |
+| [use-t-throws-async-well](docs/rules/use-t-throws-async-well.md)     | Ensure that `t.throwsAsync()` and `t.notThrowsAsync()` are awaited.                                                      | ✅  |    |    | 🔧 |    |
+| [use-t-well](docs/rules/use-t-well.md)                               | Disallow the incorrect use of `t`.                                                                                       | ✅  |    |    | 🔧 |    |
+| [use-test](docs/rules/use-test.md)                                   | Ensure that AVA is imported with `test` as the variable name.                                                            | ✅  |    |    |    |    |
+| [use-true-false](docs/rules/use-true-false.md)                       | Ensure that `t.true()`/`t.false()` are used instead of `t.truthy()`/`t.falsy()`.                                         | ✅  |    |    |    |    |
 
 <!-- end auto-generated rules list -->
 


### PR DESCRIPTION
First stable [v1.0.0](https://github.com/bmish/eslint-doc-generator/releases/tag/v1.0.0) release of [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator).

Originally added in:
* https://github.com/avajs/eslint-plugin-ava/pull/348

I ran `npm run update:eslint-docs` to update the docs.