### PR TITLE
Disallow extra properties in rule options

### DIFF
--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -399,6 +399,7 @@ const schema = [{
 			default: undefined,
 		},
 	},
+	additionalProperties: false,
 }];
 
 module.exports = {

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -60,6 +60,7 @@ const schema = [{
 			type: 'array',
 		},
 	},
+	additionalProperties: false,
 }];
 
 module.exports = {

--- a/rules/no-import-test-files.js
+++ b/rules/no-import-test-files.js
@@ -72,6 +72,7 @@ const schema = [{
 			type: 'array',
 		},
 	},
+	additionalProperties: false,
 }];
 
 module.exports = {

--- a/rules/test-title-format.js
+++ b/rules/test-title-format.js
@@ -45,6 +45,7 @@ const schema = [
 				default: undefined,
 			},
 		},
+		additionalProperties: false,
 	},
 ];
 


### PR DESCRIPTION
Some rules, for example [assertion-arguments](https://github.com/avajs/eslint-plugin-ava/blob/19be3c7ca30b36be9ded987ee6e5b3bc22f4448a/rules/assertion-arguments.js#L392) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.