### PR TITLE
Refactor to get rid of outdated `enhance-visitors` dependency

### DIFF
--- a/create-ava-rule.js
+++ b/create-ava-rule.js
@@ -1,9 +1,7 @@
-import enhance from 'enhance-visitors';
 import {getTestModifiers, unwrapTypeExpression} from './util.js';
 
-export default () => {
+export default context => {
 	let isTestFile = false;
-	let currentTestNode;
 	const testIdentifiers = new Set();
 
 	function isTestFunctionCall(node) {
@@ -18,11 +16,8 @@ export default () => {
 		return false;
 	}
 
-	function getTestModifierNames(node) {
-		return getTestModifiers(node).map(property => property.name);
-	}
+	const getModifierNames = node => getTestModifiers(node).map(property => property.name);
 
-	/* eslint quote-props: [2, "as-needed"] */
 	const predefinedRules = {
 		ImportDeclaration(node) {
 			if (node.source.value !== 'ava' || node.importKind === 'type') {
@@ -51,18 +46,6 @@ export default () => {
 				testIdentifiers.add(node.id.name);
 			}
 		},
-		CallExpression(node) {
-			if (isTestFunctionCall(node.callee)) {
-				// Entering test function
-				currentTestNode = node;
-			}
-		},
-		'CallExpression:exit'(node) {
-			if (currentTestNode === node) {
-				// Leaving test function
-				currentTestNode = undefined;
-			}
-		},
 		'Program:exit'() {
 			isTestFile = false;
 			testIdentifiers.clear();
@@ -70,18 +53,50 @@ export default () => {
 	};
 
 	return {
-		hasTestModifier: module_ => getTestModifierNames(currentTestNode).includes(module_),
-		hasNoUtilityModifier() {
-			const modifiers = getTestModifierNames(currentTestNode);
+		isInTestFile: () => isTestFile,
+		isTestNode: node => node.type === 'CallExpression' && isTestFunctionCall(node.callee),
+		isInTestNode(node) {
+			if (node.type === 'CallExpression' && isTestFunctionCall(node.callee)) {
+				return node;
+			}
+
+			const ancestors = context.sourceCode.getAncestors(node);
+			for (let index = ancestors.length - 1; index >= 0; index--) {
+				const ancestor = ancestors[index];
+				if (ancestor.type === 'CallExpression' && isTestFunctionCall(ancestor.callee)) {
+					return ancestor;
+				}
+			}
+
+			return undefined;
+		},
+		hasTestModifier: (node, modifier) => getModifierNames(node).includes(modifier),
+		hasNoUtilityModifier(node) {
+			const modifiers = getModifierNames(node);
 			return !modifiers.includes('before')
 				&& !modifiers.includes('beforeEach')
 				&& !modifiers.includes('after')
 				&& !modifiers.includes('afterEach')
 				&& !modifiers.includes('macro');
 		},
-		isInTestFile: () => isTestFile,
-		isInTestNode: () => currentTestNode,
-		isTestNode: node => currentTestNode === node,
-		merge: customHandlers => enhance.mergeVisitors([predefinedRules, customHandlers]),
+		merge: customHandlers => ({
+			...predefinedRules,
+			...Object.fromEntries(Object.entries(customHandlers).map(([key, custom]) => {
+				const predefined = predefinedRules[key];
+				if (!predefined) {
+					return [key, custom];
+				}
+
+				return [key, key.endsWith(':exit')
+					? node => {
+						custom(node);
+						predefined(node);
+					}
+					: node => {
+						predefined(node);
+						custom(node);
+					}];
+			})),
+		}),
 	};
 };

--- a/docs/rules/no-duplicate-modifiers.md
+++ b/docs/rules/no-duplicate-modifiers.md
@@ -2,7 +2,7 @@
 
 📝 Disallow duplicate test modifiers.
 
-❌ This rule is [deprecated](https://github.com/avajs/eslint-plugin-ava/blob/v16.0.0/docs/rules/no-duplicate-modifiers.md). Replaced by `ava/no-invalid-modifier-chain` which covers more cases.
+❌ This rule is [deprecated](https://github.com/avajs/eslint-plugin-ava/blob/v16.0.1/docs/rules/no-duplicate-modifiers.md). Replaced by `ava/no-invalid-modifier-chain` which covers more cases.
 
 🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 

--- a/docs/rules/no-unknown-modifiers.md
+++ b/docs/rules/no-unknown-modifiers.md
@@ -2,7 +2,7 @@
 
 📝 Disallow unknown test modifiers.
 
-❌ This rule is [deprecated](https://github.com/avajs/eslint-plugin-ava/blob/v16.0.0/docs/rules/no-unknown-modifiers.md). Replaced by `ava/no-invalid-modifier-chain` which covers more cases.
+❌ This rule is [deprecated](https://github.com/avajs/eslint-plugin-ava/blob/v16.0.1/docs/rules/no-unknown-modifiers.md). Replaced by `ava/no-invalid-modifier-chain` which covers more cases.
 
 🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/avajs/eslint-plugin-ava#recommended-config).
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
 	"dependencies": {
 		"@eslint-community/eslint-utils": "^4.9.1",
 		"@eslint/json": "^1.0.0",
-		"enhance-visitors": "^1.0.0",
 		"espree": "^11.1.0",
 		"espurify": "^3.2.0",
 		"micro-spelling-correcter": "^1.1.1",

--- a/rules/assertion-arguments.js
+++ b/rules/assertion-arguments.js
@@ -1,9 +1,8 @@
-import {visitIf} from 'enhance-visitors';
 import {
 	getStaticValue, isOpeningParenToken, isCommaToken, findVariable,
 } from '@eslint-community/eslint-utils';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID_TOO_FEW = 'too-few-arguments';
 const MESSAGE_ID_TOO_MANY = 'too-many-arguments';
@@ -227,16 +226,17 @@ function isString(node) {
 }
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	const options = context.options[0];
 	const enforcesMessage = Boolean(options.message);
 	const shouldHaveMessage = options.message !== 'never';
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			const {callee} = node;
 
 			if (
@@ -352,7 +352,7 @@ const create = context => {
 					context.report({node, messageId: MESSAGE_ID_NOT_STRING});
 				}
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/failing-test-url.js
+++ b/rules/failing-test-url.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -7,13 +6,14 @@ const MESSAGE_ID = 'failing-test-url';
 const urlPattern = /https?:\/\/\S+/;
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			const propertyNode = util.getTestModifier(node, 'failing');
 			if (!propertyNode) {
 				return;
@@ -28,7 +28,7 @@ const create = context => {
 					messageId: MESSAGE_ID,
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/hooks-order.js
+++ b/rules/hooks-order.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -40,7 +39,7 @@ const buildMessage = (name, orders, visited) => {
 };
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	const orders = buildOrders([
 		'before',
@@ -89,10 +88,11 @@ const create = context => {
 
 	const selectors = {};
 	for (const check of checks) {
-		selectors[check.selector] = visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		selectors[check.selector] = node => {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			visited[check.name] = node;
 
 			const message = buildMessage(check.name, orders, visited);
@@ -136,7 +136,7 @@ const create = context => {
 					},
 				});
 			}
-		});
+		};
 	}
 
 	return ava.merge(selectors);

--- a/rules/max-asserts.js
+++ b/rules/max-asserts.js
@@ -1,22 +1,22 @@
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'max-asserts';
 
 const notAssertionMethods = new Set(['plan', 'end']);
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	const {max: maxAssertions} = context.options[0];
 	let assertionCount = 0;
 	let nodeToReport;
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			const {callee} = node;
 
 			if (callee.type !== 'MemberExpression') {
@@ -40,8 +40,12 @@ const create = context => {
 					nodeToReport = node;
 				}
 			}
-		}),
-		'CallExpression:exit': visitIf([ava.isTestNode])(() => {
+		},
+		'CallExpression:exit'(node) {
+			if (!ava.isTestNode(node)) {
+				return;
+			}
+
 			// Leaving test function
 			if (assertionCount > maxAssertions) {
 				context.report({
@@ -53,7 +57,7 @@ const create = context => {
 
 			assertionCount = 0;
 			nodeToReport = undefined;
-		}),
+		},
 	});
 };
 

--- a/rules/no-async-fn-without-await.js
+++ b/rules/no-async-fn-without-await.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -6,7 +5,7 @@ const MESSAGE_ID = 'no-async-fn-without-await';
 const MESSAGE_ID_SUGGESTION = 'no-async-fn-without-await-suggestion';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	let testUsed = false;
 	let asyncTest;
 	let nestedFunctionDepth = 0;
@@ -32,22 +31,24 @@ const create = context => {
 	const isAsync = node => Boolean(node?.async);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			asyncTest = (isAsync(node.arguments[0]) && node.arguments[0])
 				|| (isAsync(node.arguments[1]) && node.arguments[1]);
-		}),
+		},
 		':function': enterFunction,
 		':function:exit': exitFunction,
 		AwaitExpression: registerUseOfAwait,
 		YieldExpression: registerUseOfAwait,
 		'ForOfStatement[await=true]': registerUseOfAwait,
-		'CallExpression:exit': visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(() => {
+		'CallExpression:exit'(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			if (asyncTest && !testUsed) {
 				const {sourceCode} = context;
 				const asyncToken = sourceCode.getFirstToken(asyncTest, token => token.value === 'async');
@@ -68,7 +69,7 @@ const create = context => {
 			asyncTest = undefined;
 			testUsed = false;
 			nestedFunctionDepth = 0;
-		}),
+		},
 	});
 };
 

--- a/rules/no-commented-tests.js
+++ b/rules/no-commented-tests.js
@@ -6,7 +6,7 @@ const MESSAGE_ID = 'no-commented-tests';
 const commentedTestPattern = /^\s*\*?\s*(?:test|serial)\s*(?:\.\s*\w+\s*)*\(/;
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
 		'Program:exit'() {

--- a/rules/no-conditional-assertion.js
+++ b/rules/no-conditional-assertion.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -269,21 +268,30 @@ function shouldTrackConditionalAncestor(node, child) {
 }
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([ava.isInTestFile, ava.isInTestNode])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile()) {
+				return;
+			}
+
+			const testNode = ava.isInTestNode(node);
+			if (!testNode) {
+				return;
+			}
+
 			if (!isAssertionCall(node)) {
 				return;
 			}
 
-			for (const conditional of conditionalAncestors(node, ava.isInTestNode())) {
+			for (const conditional of conditionalAncestors(node, testNode)) {
 				if (!isBalanced(conditional)) {
 					context.report({node, messageId: MESSAGE_ID});
 					break;
 				}
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-duplicate-hooks.js
+++ b/rules/no-duplicate-hooks.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -7,14 +6,15 @@ const MESSAGE_ID = 'no-duplicate-hooks';
 const hookNames = new Set(['before', 'after', 'beforeEach', 'afterEach']);
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	const seen = new Set();
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			const modifiers = util.getTestModifiers(node).map(property => property.name);
 
 			const hook = modifiers.find(name => hookNames.has(name));
@@ -35,7 +35,7 @@ const create = context => {
 			} else {
 				seen.add(name);
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-duplicate-modifiers.js
+++ b/rules/no-duplicate-modifiers.js
@@ -1,19 +1,19 @@
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'no-duplicate-modifiers';
 
 const sortByName = (a, b) => a.name.localeCompare(b.name);
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			const testModifiers = util.getTestModifiers(node).sort(sortByName);
 
 			if (testModifiers.length === 0) {
@@ -36,7 +36,7 @@ const create = context => {
 					});
 				}
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -1,8 +1,7 @@
 import {isDeepStrictEqual} from 'node:util';
 import espurify from 'espurify';
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'no-identical-title';
 
@@ -20,17 +19,17 @@ function isTitleUsed(usedTitleNodes, titleNode) {
 }
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	let usedTitleNodes = [];
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-			ava.hasNoUtilityModifier,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node) || !ava.hasNoUtilityModifier(node)) {
+				return;
+			}
+
 			const arguments_ = node.arguments;
-			const titleNode = arguments_.length > 1 || ava.hasTestModifier('todo') ? arguments_[0] : undefined;
+			const titleNode = arguments_.length > 1 || ava.hasTestModifier(node, 'todo') ? arguments_[0] : undefined;
 
 			// Don't flag computed titles
 			if (!titleNode || !isStatic(titleNode)) {
@@ -51,7 +50,7 @@ const create = context => {
 			}
 
 			usedTitleNodes.push(purify(titleNode));
-		}),
+		},
 		'Program:exit'() {
 			usedTitleNodes = [];
 		},

--- a/rules/no-ignored-test-files.js
+++ b/rules/no-ignored-test-files.js
@@ -1,6 +1,5 @@
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID_HELPER = 'helper-file';
 const MESSAGE_ID_IGNORED = 'ignored-file';
@@ -15,14 +14,15 @@ const create = context => {
 
 	let hasTestCall = false;
 
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(() => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			hasTestCall = true;
-		}),
+		},
 		'Program:exit'(node) {
 			if (!hasTestCall) {
 				return;

--- a/rules/no-incorrect-deep-equal.js
+++ b/rules/no-incorrect-deep-equal.js
@@ -1,6 +1,5 @@
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'no-deep-equal-with-primitive';
 
@@ -27,7 +26,7 @@ const buildNotDeepEqualMessage = (context, node) => {
 };
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	const callExpression = 'CallExpression';
 	const deepEqual = '[callee.property.name="deepEqual"]';
@@ -38,42 +37,48 @@ const create = context => {
 	const argumentsTemplate = ':matches([arguments.0.type="TemplateLiteral"],[arguments.1.type="TemplateLiteral"])';
 
 	return ava.merge({
-		[`${callExpression}${deepEqual}${argumentsLiteral}`]: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		[`${callExpression}${deepEqual}${argumentsLiteral}`](node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			buildDeepEqualMessage(context, node);
-		}),
-		[`${callExpression}${deepEqual}${argumentsUndefined}`]: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		},
+		[`${callExpression}${deepEqual}${argumentsUndefined}`](node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			buildDeepEqualMessage(context, node);
-		}),
-		[`${callExpression}${deepEqual}${argumentsTemplate}`]: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		},
+		[`${callExpression}${deepEqual}${argumentsTemplate}`](node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			buildDeepEqualMessage(context, node);
-		}),
-		[`${callExpression}${notDeepEqual}${argumentsLiteral}`]: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		},
+		[`${callExpression}${notDeepEqual}${argumentsLiteral}`](node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			buildNotDeepEqualMessage(context, node);
-		}),
-		[`${callExpression}${notDeepEqual}${argumentsUndefined}`]: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		},
+		[`${callExpression}${notDeepEqual}${argumentsUndefined}`](node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			buildNotDeepEqualMessage(context, node);
-		}),
-		[`${callExpression}${notDeepEqual}${argumentsTemplate}`]: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		},
+		[`${callExpression}${notDeepEqual}${argumentsTemplate}`](node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			buildNotDeepEqualMessage(context, node);
-		}),
+		},
 	});
 };
 

--- a/rules/no-inline-assertions.js
+++ b/rules/no-inline-assertions.js
@@ -1,17 +1,17 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
 const MESSAGE_ID = 'no-inline-assertions';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			const functionArgumentIndex = node.arguments.length - 1;
 			if (functionArgumentIndex > 1) {
 				return;
@@ -31,7 +31,7 @@ const create = context => {
 					fix: fixer => [fixer.insertTextBefore(body, '{'), fixer.insertTextAfter(body, '}')],
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-invalid-modifier-chain.js
+++ b/rules/no-invalid-modifier-chain.js
@@ -1,7 +1,6 @@
-import {visitIf} from 'enhance-visitors';
 import {findVariable} from '@eslint-community/eslint-utils';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'no-invalid-modifier-chain';
 const SUGGESTION_MESSAGE_ID = 'no-invalid-modifier-chain-suggestion';
@@ -147,14 +146,15 @@ function getCalleeText(chain, prefix, hasImplicitSerial) {
 }
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	const {sourceCode} = context;
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			const testModifiers = util.getTestModifiers(node);
 			const modifierNames = testModifiers.map(property => property.name);
 
@@ -189,7 +189,7 @@ const create = context => {
 						: [],
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-negated-assertion.js
+++ b/rules/no-negated-assertion.js
@@ -1,6 +1,5 @@
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'no-negated-assertion';
 
@@ -21,13 +20,14 @@ const doubleNegatedPairs = {
 const getArgumentText = (source, argument) => argument.type === 'SequenceExpression' ? `(${source.getText(argument)})` : source.getText(argument);
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			if (node.callee.type !== 'MemberExpression') {
 				return;
 			}
@@ -94,7 +94,7 @@ const create = context => {
 					];
 				},
 			});
-		}),
+		},
 	});
 };
 

--- a/rules/no-nested-assertions.js
+++ b/rules/no-nested-assertions.js
@@ -1,18 +1,18 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
 const MESSAGE_ID = 'no-nested-assertions';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	const assertionCallStack = [];
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			if (node.callee.type !== 'MemberExpression') {
 				return;
 			}
@@ -35,7 +35,7 @@ const create = context => {
 			if (methodName !== 'try') {
 				assertionCallStack.push(node);
 			}
-		}),
+		},
 		'CallExpression:exit'(node) {
 			if (assertionCallStack.length > 0 && assertionCallStack.at(-1) === node) {
 				assertionCallStack.pop();

--- a/rules/no-nested-tests.js
+++ b/rules/no-nested-tests.js
@@ -1,18 +1,18 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
 const MESSAGE_ID = 'no-nested-tests';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	const testNodeStack = [];
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			testNodeStack.push(node);
 			if (testNodeStack.length >= 2) {
 				context.report({
@@ -20,7 +20,7 @@ const create = context => {
 					messageId: MESSAGE_ID,
 				});
 			}
-		}),
+		},
 
 		'CallExpression:exit'(node) {
 			if (testNodeStack.length > 0 && testNodeStack.at(-1) === node) {

--- a/rules/no-only-test.js
+++ b/rules/no-only-test.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -6,13 +5,14 @@ const MESSAGE_ID = 'no-only-test';
 const MESSAGE_ID_SUGGESTION = 'no-only-test-suggestion';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			const propertyNode = util.getTestModifier(node, 'only');
 			if (propertyNode) {
 				context.report({
@@ -28,7 +28,7 @@ const create = context => {
 					}],
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-skip-assert.js
+++ b/rules/no-skip-assert.js
@@ -1,18 +1,18 @@
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'no-skip-assert';
 const MESSAGE_ID_SUGGESTION = 'no-skip-assert-suggestion';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		MemberExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		MemberExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			if (node.property.name === 'skip') {
 				const root = util.getRootNode(node);
 				if (util.isTestObject(root.object.name) && util.assertionMethods.has(root.property.name)) {
@@ -30,7 +30,7 @@ const create = context => {
 					});
 				}
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-skip-test.js
+++ b/rules/no-skip-test.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -6,13 +5,14 @@ const MESSAGE_ID = 'no-skip-test';
 const MESSAGE_ID_SUGGESTION = 'no-skip-test-suggestion';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			const propertyNode = util.getTestModifier(node, 'skip');
 			if (propertyNode) {
 				context.report({
@@ -28,7 +28,7 @@ const create = context => {
 					}],
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-todo-implementation.js
+++ b/rules/no-todo-implementation.js
@@ -1,21 +1,21 @@
-import {visitIf} from 'enhance-visitors';
 import {isCommaToken} from '@eslint-community/eslint-utils';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'no-todo-implementation';
 const MESSAGE_ID_REMOVE_TODO = 'no-todo-implementation-remove-todo';
 const MESSAGE_ID_REMOVE_IMPLEMENTATION = 'no-todo-implementation-remove-implementation';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
-			if (ava.hasTestModifier('todo') && node.arguments.some(argument => util.isFunctionExpression(argument))) {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
+			if (ava.hasTestModifier(node, 'todo') && node.arguments.some(argument => util.isFunctionExpression(argument))) {
 				const {sourceCode} = context;
 				const functionArgument = node.arguments.find(argument => util.isFunctionExpression(argument));
 
@@ -45,7 +45,7 @@ const create = context => {
 					],
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-todo-test.js
+++ b/rules/no-todo-test.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -6,14 +5,15 @@ const MESSAGE_ID = 'no-todo-test';
 const MESSAGE_ID_SUGGESTION = 'no-todo-test-suggestion';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
-			if (ava.hasTestModifier('todo')) {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
+			if (ava.hasTestModifier(node, 'todo')) {
 				context.report({
 					node,
 					messageId: MESSAGE_ID,
@@ -27,7 +27,7 @@ const create = context => {
 					}],
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-unknown-modifiers.js
+++ b/rules/no-unknown-modifiers.js
@@ -1,6 +1,5 @@
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'no-unknown-modifiers';
 const MESSAGE_ID_SUGGESTION = 'no-unknown-modifiers-suggestion';
@@ -23,13 +22,14 @@ const knownModifiers = new Set([
 ]);
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			const testModifiers = util.getTestModifiers(node);
 
 			for (const modifier of testModifiers) {
@@ -67,7 +67,7 @@ const create = context => {
 					}],
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/no-useless-t-pass.js
+++ b/rules/no-useless-t-pass.js
@@ -1,7 +1,6 @@
-import {visitIf} from 'enhance-visitors';
 import {findVariable} from '@eslint-community/eslint-utils';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'no-useless-t-pass';
 
@@ -106,16 +105,22 @@ function getTestObjectKey(callee, sourceCode, allowedTestObjectVariables) {
 }
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	const {sourceCode} = context;
 	let hasPlanByTestObject = new Map();
 	let passNodesByTestObject = new Map();
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile()) {
+				return;
+			}
+
+			const currentTestNode = ava.isInTestNode(node);
+			if (!currentTestNode) {
+				return;
+			}
+
 			const {callee} = node;
 			if (
 				callee.type !== 'MemberExpression'
@@ -125,7 +130,6 @@ const create = context => {
 				return;
 			}
 
-			const currentTestNode = ava.isInTestNode();
 			const allowedTestObjectVariables = getAllowedTestObjectVariables(node, sourceCode, currentTestNode);
 			const testObjectKey = getTestObjectKey(callee, sourceCode, allowedTestObjectVariables);
 			if (!testObjectKey) {
@@ -140,26 +144,28 @@ const create = context => {
 				nodes.push(node);
 				passNodesByTestObject.set(testObjectKey, nodes);
 			}
-		}),
-		'CallExpression:exit': visitIf([ava.isInTestNode])(node => {
-			if (ava.isTestNode(node)) {
-				for (const [testObjectKey, passNodes] of passNodesByTestObject) {
-					if (hasPlanByTestObject.get(testObjectKey)) {
-						continue;
-					}
+		},
+		'CallExpression:exit'(node) {
+			if (!ava.isTestNode(node)) {
+				return;
+			}
 
-					for (const node of passNodes) {
-						context.report({
-							node,
-							messageId: MESSAGE_ID,
-						});
-					}
+			for (const [testObjectKey, passNodes] of passNodesByTestObject) {
+				if (hasPlanByTestObject.get(testObjectKey)) {
+					continue;
 				}
 
-				hasPlanByTestObject = new Map();
-				passNodesByTestObject = new Map();
+				for (const node of passNodes) {
+					context.report({
+						node,
+						messageId: MESSAGE_ID,
+					});
+				}
 			}
-		}),
+
+			hasPlanByTestObject = new Map();
+			passNodesByTestObject = new Map();
+		},
 	});
 };
 

--- a/rules/prefer-async-await.js
+++ b/rules/prefer-async-await.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -30,12 +29,13 @@ function containsThen(node) {
 }
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
-	const check = visitIf([
-		ava.isInTestFile,
-		ava.isInTestNode,
-	])(node => {
+	const check = node => {
+		if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+			return;
+		}
+
 		if (node.body.type !== 'BlockStatement') {
 			return;
 		}
@@ -79,7 +79,7 @@ const create = context => {
 				}
 			}
 		}
-	});
+	};
 
 	return ava.merge({
 		ArrowFunctionExpression: check,

--- a/rules/prefer-power-assert.js
+++ b/rules/prefer-power-assert.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -38,20 +37,21 @@ const isNotAllowedAssertion = callee => {
 };
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			if (isNotAllowedAssertion(node.callee)) {
 				context.report({
 					node,
 					messageId: MESSAGE_ID,
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/prefer-t-regex.js
+++ b/rules/prefer-t-regex.js
@@ -1,11 +1,10 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
 const MESSAGE_ID = 'prefer-t-regex';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	const booleanTests = new Set([
 		'true',
@@ -193,10 +192,11 @@ const create = context => {
 	};
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			if (!node?.callee?.property) {
 				return;
 			}
@@ -215,7 +215,7 @@ const create = context => {
 			} else if (isEqualityAssertion) {
 				equalityHandler(node);
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/prefer-t-throws.js
+++ b/rules/prefer-t-throws.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -105,13 +104,14 @@ function hasDirectAwait(node) {
 }
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		TryStatement: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		TryStatement(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			if (!node.handler) {
 				return;
 			}
@@ -130,7 +130,7 @@ const create = context => {
 				node,
 				messageId: isAsync ? MESSAGE_ID_ASYNC : MESSAGE_ID_SYNC,
 			});
-		}),
+		},
 	});
 };
 

--- a/rules/require-assertion.js
+++ b/rules/require-assertion.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import {findVariable, getStaticValue} from '@eslint-community/eslint-utils';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
@@ -145,13 +144,17 @@ function isTestObjectArgument(argument, sourceCode, testObjectVariable) {
 }
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 	const {sourceCode} = context;
 	let assertionCount = 0;
 	let currentTestState;
 
 	return ava.merge({
-		CallExpression: visitIf([ava.isInTestFile, ava.isInTestNode])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			const isCurrentTestNode = ava.isTestNode(node);
 
 			if (isCurrentTestNode) {
@@ -184,9 +187,13 @@ const create = context => {
 			if (util.assertionMethods.has(methodName) || methodName === 'plan') {
 				assertionCount++;
 			}
-		}),
-		'CallExpression:exit': visitIf([ava.isTestNode])(node => {
-			if (ava.hasNoUtilityModifier() && !ava.hasTestModifier('todo') && assertionCount === 0) {
+		},
+		'CallExpression:exit'(node) {
+			if (!ava.isTestNode(node)) {
+				return;
+			}
+
+			if (ava.hasNoUtilityModifier(node) && !ava.hasTestModifier(node, 'todo') && assertionCount === 0) {
 				context.report({
 					node,
 					messageId: MESSAGE_ID,
@@ -195,7 +202,7 @@ const create = context => {
 
 			currentTestState = undefined;
 			assertionCount = 0;
-		}),
+		},
 	});
 };
 

--- a/rules/test-title-format.js
+++ b/rules/test-title-format.js
@@ -1,11 +1,10 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
 const MESSAGE_ID = 'test-title-format';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	let titleRegExp;
 	if (context.options[0]?.format) {
@@ -15,12 +14,12 @@ const create = context => {
 	}
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-			ava.hasNoUtilityModifier,
-		])(node => {
-			const requiredLength = ava.hasTestModifier('todo') ? 1 : 2;
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node) || !ava.hasNoUtilityModifier(node)) {
+				return;
+			}
+
+			const requiredLength = ava.hasTestModifier(node, 'todo') ? 1 : 2;
 			const hasTitle = node.arguments.length >= requiredLength;
 
 			if (hasTitle) {
@@ -33,7 +32,7 @@ const create = context => {
 					});
 				}
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/test-title.js
+++ b/rules/test-title.js
@@ -1,4 +1,3 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
@@ -9,14 +8,14 @@ const MESSAGE_ID_WHITESPACE = 'title-whitespace';
 const toStringLiteral = value => JSON.stringify(value);
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-			ava.hasNoUtilityModifier,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node) || !ava.hasNoUtilityModifier(node)) {
+				return;
+			}
+
 			const firstArgumentIsFunction = node.arguments.length === 0 || util.isFunctionExpression(node.arguments[0]);
 
 			if (firstArgumentIsFunction) {
@@ -83,7 +82,7 @@ const create = context => {
 					});
 				}
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/use-t-throws-async-well.js
+++ b/rules/use-t-throws-async-well.js
@@ -1,24 +1,29 @@
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID = 'use-t-throws-async-well';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile()) {
+				return;
+			}
+
+			const testNode = ava.isInTestNode(node);
+			if (!testNode) {
+				return;
+			}
+
 			if (
 				node.parent.type === 'ExpressionStatement'
 				&& node.callee.type === 'MemberExpression'
 				&& (node.callee.property.name === 'throwsAsync' || node.callee.property.name === 'notThrowsAsync')
 				&& util.isTestObject(node.callee.object.name)
 			) {
-				if (ava.isInTestNode().arguments[0].async) {
+				if (testNode.arguments[0].async) {
 					context.report({
 						node,
 						messageId: MESSAGE_ID,
@@ -33,7 +38,7 @@ const create = context => {
 					});
 				}
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/use-t-well.js
+++ b/rules/use-t-well.js
@@ -1,7 +1,6 @@
-import {visitIf} from 'enhance-visitors';
+import createAvaRule from '../create-ava-rule.js';
 import MicroSpellingCorrecter from 'micro-spelling-correcter';
 import util from '../util.js';
-import createAvaRule from '../create-ava-rule.js';
 
 const MESSAGE_ID_NOT_FUNCTION = 'not-function';
 const MESSAGE_ID_UNKNOWN_ASSERTION = 'unknown-assertion';
@@ -76,13 +75,14 @@ const getMemberNodes = node => {
 };
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			if (node.callee.type !== 'MemberExpression'
 				&& util.isTestObject(node.callee.name)) {
 				context.report({
@@ -90,11 +90,12 @@ const create = context => {
 					messageId: MESSAGE_ID_NOT_FUNCTION,
 				});
 			}
-		}),
-		MemberExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		},
+		MemberExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			if (node.parent.type === 'MemberExpression'
 				|| !util.isTestObject(util.getNameOfRootNodeObject(node))) {
 				return;
@@ -205,7 +206,7 @@ const create = context => {
 					},
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/use-t.js
+++ b/rules/use-t.js
@@ -1,24 +1,24 @@
-import {visitIf} from 'enhance-visitors';
 import createAvaRule from '../create-ava-rule.js';
 import util from '../util.js';
 
 const MESSAGE_ID = 'use-t';
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isTestNode(node)) {
+				return;
+			}
+
 			const index = node.arguments.length - 1;
 			if (index > 1) {
 				return;
 			}
 
 			let implementationArgument = node.arguments[index];
-			if (ava.hasTestModifier('macro') && implementationArgument.type === 'ObjectExpression') {
+			if (ava.hasTestModifier(node, 'macro') && implementationArgument.type === 'ObjectExpression') {
 				const execProperty = implementationArgument.properties.find(p => p.key?.name === 'exec');
 				implementationArgument = execProperty?.value;
 			}
@@ -33,7 +33,7 @@ const create = context => {
 					messageId: MESSAGE_ID,
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/rules/use-true-false.js
+++ b/rules/use-true-false.js
@@ -1,9 +1,8 @@
 import {isDeepStrictEqual} from 'node:util';
 import * as espree from 'espree';
 import espurify from 'espurify';
-import {visitIf} from 'enhance-visitors';
-import util from '../util.js';
 import createAvaRule from '../create-ava-rule.js';
+import util from '../util.js';
 
 const MESSAGE_ID_TRUE = 'use-true';
 const MESSAGE_ID_FALSE = 'use-false';
@@ -51,13 +50,14 @@ function matchesKnownBooleanExpression(argument) {
 }
 
 const create = context => {
-	const ava = createAvaRule();
+	const ava = createAvaRule(context);
 
 	return ava.merge({
-		CallExpression: visitIf([
-			ava.isInTestFile,
-			ava.isInTestNode,
-		])(node => {
+		CallExpression(node) {
+			if (!ava.isInTestFile() || !ava.isInTestNode(node)) {
+				return;
+			}
+
 			if (
 				node.callee.type !== 'MemberExpression'
 				|| !util.isTestObject(node.callee.object.name)
@@ -128,7 +128,7 @@ const create = context => {
 					},
 				});
 			}
-		}),
+		},
 	});
 };
 

--- a/xo.config.js
+++ b/xo.config.js
@@ -34,7 +34,13 @@ export default [
 	{
 		files: ['create-ava-rule.js'],
 		rules: {
+			'eslint-plugin/prefer-object-rule': 'off',
+			'eslint-plugin/prefer-message-ids': 'off',
+			'eslint-plugin/require-meta-docs-description': 'off',
+			'eslint-plugin/require-meta-docs-recommended': 'off',
 			'eslint-plugin/require-meta-docs-url': 'off',
+			'eslint-plugin/require-meta-schema': 'off',
+			'eslint-plugin/require-meta-type': 'off',
 			'unicorn/no-anonymous-default-export': 'off',
 		},
 	},


### PR DESCRIPTION
Hello!

I noticed that `enhance-visitors` package of this package:
- Last updated 10 years ago;
- Brings barely maintained & heavy `lodash` dependency, which recently received a security vulnerability;
- Quite trivial;
- Virtually [used by only 2 ESLint plugins](https://www.npmjs.com/package/enhance-visitors?activeTab=dependents).

In this PR, I decided to refactor the code to remove the dependency on it:
- `visitIf` wrapper calls was replaced with native control flow expressions;
- `mergeVisitors` implementation was inlined.

Along with that, I've slightly improve the architecture of the rules creator to get rid of the `currentTestNode` flag.